### PR TITLE
#7 fix: db migration is not executed when using legacy backend

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn lint-staged
+yarn lint-staged && yarn tsc

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ export default async function createPlugin(
   return await createRouter({
     logger: env.logger,
     config: env.config,
-    audit: env.audit,
+    cache: env.cache.getClient(),
     database: env.database,
   });
 }

--- a/plugins/infrawallet-backend/package.json
+++ b/plugins/infrawallet-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electrolux-oss/plugin-infrawallet-backend",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/plugins/infrawallet-backend/seeds/init.js
+++ b/plugins/infrawallet-backend/seeds/init.js
@@ -1,18 +1,14 @@
-exports.seed = async (knex) => {
+exports.seed = async knex => {
   await knex('category_mappings').insert([
     {
       provider: 'azure',
       category: 'Analytics',
       // make it compatible with sqlite
-      cloud_service_names: JSON.stringify([
-        'Azure Monitor',
-        'Log Analytics',
-        'Network Watcher',
-      ]),
+      cloud_service_names: JSON.stringify(['Event Hubs', 'Log Analytics']),
     },
     {
       provider: 'azure',
-      category: 'Application-Integration',
+      category: 'Application Integration',
       cloud_service_names: JSON.stringify(['Logic Apps']),
     },
     {
@@ -21,9 +17,15 @@ exports.seed = async (knex) => {
       cloud_service_names: JSON.stringify([
         'Virtual Machines',
         'Azure App Service',
-        'Azure Data Factory v2',
         'Functions',
+      ]),
+    },
+    {
+      provider: 'azure',
+      category: 'Containers',
+      cloud_service_names: JSON.stringify([
         'Azure Container Apps',
+        'Container Registry',
       ]),
     },
     {
@@ -31,6 +33,7 @@ exports.seed = async (knex) => {
       category: 'Database',
       cloud_service_names: JSON.stringify([
         'Azure Cosmos DB',
+        'Azure Data Factory v2',
         'Azure Database for MySQL',
         'Redis Cache',
         'SQL Database',
@@ -38,7 +41,7 @@ exports.seed = async (knex) => {
     },
     {
       provider: 'azure',
-      category: 'Developer-Tools',
+      category: 'Developer Tools',
       cloud_service_names: JSON.stringify([
         'Azure DevOps',
         'Notification Hubs',
@@ -47,16 +50,17 @@ exports.seed = async (knex) => {
     },
     {
       provider: 'azure',
-      category: 'Internet-of-Things',
-      cloud_service_names: JSON.stringify([
-        'Event Grid',
-        'Event Hubs',
-        'IoT Hub',
-      ]),
+      category: 'DevOps',
+      cloud_service_names: JSON.stringify(['Azure Monitor']),
     },
     {
       provider: 'azure',
-      category: 'Machine-Learning',
+      category: 'Internet of Things',
+      cloud_service_names: JSON.stringify(['Event Grid', 'IoT Hub']),
+    },
+    {
+      provider: 'azure',
+      category: 'Artificial Intelligence',
       cloud_service_names: JSON.stringify([
         'Azure Cognitive Search',
         'Azure Databricks',
@@ -65,24 +69,29 @@ exports.seed = async (knex) => {
     },
     {
       provider: 'azure',
+      category: 'Management & Governance',
+      cloud_service_names: JSON.stringify(['Network Watcher']),
+    },
+    {
+      provider: 'azure',
       category: 'Networking',
       cloud_service_names: JSON.stringify([
+        'Azure DNS',
         'Azure Front Door Service',
         'Bandwidth',
         'Content Delivery Network',
         'Load Balancer',
         'NAT Gateway',
+        'Network Traversal',
         'Service Bus',
         'Traffic Manager',
         'Virtual Network',
-        'Network Traversal',
-        'Azure DNS',
         'VPN Gateway',
       ]),
     },
     {
       provider: 'azure',
-      category: 'Security-Identity-Compliance',
+      category: 'Security, Identity, & Compliance',
       cloud_service_names: JSON.stringify([
         'Azure Firewall',
         'Key Vault',
@@ -92,29 +101,30 @@ exports.seed = async (knex) => {
     {
       provider: 'azure',
       category: 'Storage',
-      cloud_service_names: JSON.stringify(['Container Registry', 'Storage']),
+      cloud_service_names: JSON.stringify(['Storage']),
     },
     {
       provider: 'aws',
       category: 'Analytics',
       cloud_service_names: JSON.stringify([
-        'AWS CloudTrail',
-        'AWS X-Ray',
-        'AmazonCloudWatch',
+        'Amazon Kinesis',
+        'Amazon Managed Streaming for Apache Kafka',
+        'Amazon QuickSight',
+        'AWS Glue',
       ]),
     },
     {
       provider: 'aws',
-      category: 'Application-Integration',
+      category: 'Application Integration',
       cloud_service_names: JSON.stringify([
-        'AWS Config',
         'Amazon API Gateway',
-        'AWS Service Catalog',
+        'Amazon Simple Notification Service',
+        'Amazon Simple Queue Service',
       ]),
     },
     {
       provider: 'aws',
-      category: 'Cloud-Financial-Management',
+      category: 'Cloud Financial Management',
       cloud_service_names: JSON.stringify(['AWS Cost Explorer']),
     },
     {
@@ -123,9 +133,15 @@ exports.seed = async (knex) => {
       cloud_service_names: JSON.stringify([
         'EC2 - Other',
         'Amazon Elastic Compute Cloud - Compute',
-        'Amazon Elastic Container Service for Kubernetes',
         'AWS Lambda',
-        'AWS Glue',
+      ]),
+    },
+    {
+      provider: 'aws',
+      category: 'Containers',
+      cloud_service_names: JSON.stringify([
+        'Amazon Elastic Container Service for Kubernetes',
+        'Amazon Elastic Container Registry (ECR)',
       ]),
     },
     {
@@ -134,45 +150,55 @@ exports.seed = async (knex) => {
       cloud_service_names: JSON.stringify([
         'Amazon DynamoDB',
         'Amazon ElastiCache',
-        'Amazon Kinesis',
         'Amazon Relational Database Service',
+        'Amazon Timestream',
         'DynamoDB Accelerator (DAX)',
       ]),
     },
     {
       provider: 'aws',
-      category: 'Developer-Tools',
+      category: 'Developer Tools',
+      cloud_service_names: JSON.stringify(['AWS CloudShell', 'AWS X-Ray']),
+    },
+    {
+      provider: 'aws',
+      category: 'Internet of Things',
+      cloud_service_names: JSON.stringify(['AWS IoT']),
+    },
+    {
+      provider: 'aws',
+      category: 'Management & Governance',
       cloud_service_names: JSON.stringify([
-        'Amazon Simple Notification Service',
-        'Amazon Simple Queue Service',
-        'AWS Migration Hub Refactor Spaces',
-        'AWS CloudShell',
+        'AmazonCloudWatch',
+        'AWS CloudTrail',
+        'AWS Config',
+        'AWS Service Catalog',
       ]),
     },
     {
       provider: 'aws',
-      category: 'Internet-of-Things',
-      cloud_service_names: JSON.stringify(['AWS IoT']),
+      category: 'Migration',
+      cloud_service_names: JSON.stringify([
+        'AWS Migration Hub Refactor Spaces',
+      ]),
     },
     {
       provider: 'aws',
       category: 'Networking',
       cloud_service_names: JSON.stringify([
         'Amazon Elastic Load Balancing',
-        'Amazon Managed Streaming for Apache Kafka',
         'Amazon Route 53',
-        'Amazon Timestream',
         'Amazon Virtual Private Cloud',
       ]),
     },
     {
       provider: 'aws',
-      category: 'Security-Identity-Compliance',
+      category: 'Security, Identity, & Compliance',
       cloud_service_names: JSON.stringify([
+        'Amazon GuardDuty',
         'AWS Key Management Service',
         'AWS Secrets Manager',
         'AWS Security Hub',
-        'Amazon GuardDuty',
         'AWS WAF',
       ]),
     },
@@ -180,9 +206,8 @@ exports.seed = async (knex) => {
       provider: 'aws',
       category: 'Storage',
       cloud_service_names: JSON.stringify([
-        'Amazon Simple Storage Service',
-        'Amazon EC2 Container Registry (ECR)',
         'Amazon Glacier',
+        'Amazon Simple Storage Service',
       ]),
     },
   ]);

--- a/plugins/infrawallet-backend/src/plugin.ts
+++ b/plugins/infrawallet-backend/src/plugin.ts
@@ -1,4 +1,3 @@
-import { resolvePackagePath } from '@backstage/backend-plugin-api';
 import {
   coreServices,
   createBackendPlugin,
@@ -22,33 +21,6 @@ export const infraWalletPlugin = createBackendPlugin({
         database: coreServices.database,
       },
       async init({ httpRouter, logger, config, cache, database }) {
-        // check database migrations
-        const client = await database.getClient();
-        const migrationsDir = resolvePackagePath(
-          '@electrolux-oss/plugin-infrawallet-backend',
-          'migrations',
-        );
-        if (!database.migrations?.skip) {
-          await client.migrate.latest({
-            directory: migrationsDir,
-          });
-        }
-
-        // if there are no category mappings, seed the database
-        const category_mappings_count = await client('category_mappings').count(
-          'id as c',
-        );
-        if (
-          category_mappings_count[0].c === 0 ||
-          category_mappings_count[0].c === '0'
-        ) {
-          const seedsDir = resolvePackagePath(
-            '@electrolux-oss/plugin-infrawallet-backend',
-            'seeds',
-          );
-          await client.seed.run({ directory: seedsDir });
-        }
-
         httpRouter.use(
           await createRouter({
             logger,

--- a/plugins/infrawallet/README.md
+++ b/plugins/infrawallet/README.md
@@ -186,7 +186,7 @@ export default async function createPlugin(
   return await createRouter({
     logger: env.logger,
     config: env.config,
-    audit: env.audit,
+    cache: env.cache.getClient(),
     database: env.database,
   });
 }


### PR DESCRIPTION
When attaching a plugin backend to a legacy backend system, usually it just executes the `createRouter` method. This PR moves the db migration code to `createRouter` so that both new and legacy backend systems can be supported.