### PR TITLE
#38 no need to specify location for a bigquery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "engines": {
     "node": "18 || 20"

--- a/plugins/infrawallet-backend/package.json
+++ b/plugins/infrawallet-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electrolux-oss/plugin-infrawallet-backend",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/plugins/infrawallet-backend/src/service/GCPClient.ts
+++ b/plugins/infrawallet-backend/src/service/GCPClient.ts
@@ -68,7 +68,6 @@ export class GCPClient extends InfraWalletClient {
       // Run the query as a job
       const [job] = await client.createQueryJob({
         query: sql,
-        location: 'US',
       });
 
       // Wait for the query to finish

--- a/plugins/infrawallet/package.json
+++ b/plugins/infrawallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electrolux-oss/plugin-infrawallet",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
This PR fixes #38 as we previously hardcoded the location to `US` in a Google BigQuery.