### PR TITLE
#15 feat: support configuring default view from app-config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@
 
 ## Getting started
 
+### Default Settings for Frontend
+
+Site admins can configure the default view for InfraWallet, including the default group by dimension, and the default
+query period. Add the following configurations to your `app-config.yaml` file if the default view needs to be changed.
+
+```yaml
+# note that infraWallet exists at the root level, it is not the same one for backend configurations
+infraWallet:
+  settings:
+    defaultGroupBy: none # none by default, or provider, category, service, tag:<tag_key>
+    defaultShowLastXMonths: 3 # 3 by default, or other numbers, we recommend it less than 12
+```
+
 ### Define Cloud Accounts in app-config.yaml
 
 The configuration schema of InfraWallet is defined in the [plugins/infrawallet-backend/config.d.ts](plugins/infrawallet-backend/config.d.ts) file. Users need to configure their cloud accounts in the `app-config.yaml` in the root folder.

--- a/plugins/infrawallet/README.md
+++ b/plugins/infrawallet/README.md
@@ -15,6 +15,19 @@
 
 ## Getting started
 
+### Default Settings for Frontend
+
+Site admins can configure the default view for InfraWallet, including the default group by dimension, and the default
+query period. Add the following configurations to your `app-config.yaml` file if the default view needs to be changed.
+
+```yaml
+# note that infraWallet exists at the root level, it is not the same one for backend configurations
+infraWallet:
+  settings:
+    defaultGroupBy: none # none by default, or provider, category, service, tag:<tag_key>
+    defaultShowLastXMonths: 3 # 3 by default, or other numbers, we recommend it less than 12
+```
+
 ### Define Cloud Accounts in app-config.yaml
 
 The configuration schema of InfraWallet is defined in the [plugins/infrawallet-backend/config.d.ts](plugins/infrawallet-backend/config.d.ts) file. Users need to configure their cloud accounts in the `app-config.yaml` in the root folder.

--- a/plugins/infrawallet/config.d.ts
+++ b/plugins/infrawallet/config.d.ts
@@ -1,0 +1,11 @@
+export interface Config {
+  infraWallet: {
+    /**
+     * @deepVisibility frontend
+     */
+    settings: {
+      defaultGroupBy?: string; // if not set, `none` will be used
+      defaultShowLastXMonths?: number; // if not set, 3 will be used
+    };
+  };
+}

--- a/plugins/infrawallet/package.json
+++ b/plugins/infrawallet/package.json
@@ -20,7 +20,8 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "files": [
-    "dist"
+    "dist",
+    "config.d.ts"
   ],
   "scripts": {
     "build": "backstage-cli package build",
@@ -74,5 +75,6 @@
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.13.0"
-  }
+  },
+  "configSchema": "config.d.ts"
 }

--- a/plugins/infrawallet/src/components/ReportsComponent/ReportsComponent.tsx
+++ b/plugins/infrawallet/src/components/ReportsComponent/ReportsComponent.tsx
@@ -1,5 +1,5 @@
 import { Content, Header, Page, Progress } from '@backstage/core-components';
-import { alertApiRef, useApi } from '@backstage/core-plugin-api';
+import { alertApiRef, configApiRef, useApi } from '@backstage/core-plugin-api';
 import { Chip, Grid } from '@material-ui/core';
 import Accordion from '@material-ui/core/Accordion';
 import AccordionDetails from '@material-ui/core/AccordionDetails';
@@ -56,6 +56,11 @@ const checkIfFiltersActivated = (filters: Filters): boolean => {
 };
 
 export const ReportsComponent = () => {
+  const configApi = useApi(configApiRef);
+
+  const defaultGroupBy = configApi.getOptionalString('infraWallet.settings.defaultGroupBy') ?? 'none';
+  const defaultShowLastXMonths = configApi.getOptionalNumber('infraWallet.settings.defaultShowLastXMonths') ?? 3;
+
   const MERGE_THRESHOLD = 8;
   const [submittingState, setSubmittingState] = useState<Boolean>(false);
   const [reports, setReports] = useState<Report[]>([]);
@@ -65,10 +70,10 @@ export const ReportsComponent = () => {
   const [reportsAggregatedAndMerged, setReportsAggregatedAndMerged] = useState<Report[]>([]);
   const [reportTags, setReportTags] = useState<string[]>([]);
   const [granularity, setGranularity] = useState<string>('monthly');
-  const [aggregatedBy, setAggregatedBy] = useState<string>('none');
+  const [aggregatedBy, setAggregatedBy] = useState<string>(defaultGroupBy);
   const [groups, _setGroups] = useState<string>('');
   const [monthRangeState, setMonthRangeState] = React.useState<MonthRange>({
-    startMonth: startOfMonth(addMonths(new Date(), -2)),
+    startMonth: startOfMonth(addMonths(new Date(), defaultShowLastXMonths * -1 + 1)),
     endMonth: endOfMonth(new Date()),
   });
   const [periods, setPeriods] = useState<string[]>([]);


### PR DESCRIPTION
Site admins can configure the default view for InfraWallet, including the default group by dimension, and the default
query period. Add the following configurations to your `app-config.yaml` file if the default view needs to be changed.

```yaml
# note that infraWallet exists at the root level, it is not the same one for backend configurations
infraWallet:
  settings:
    defaultGroupBy: none # none by default, or provider, category, service, tag:<tag_key>
    defaultShowLastXMonths: 3 # 3 by default, or other numbers, we recommend it less than 12
```