### PR TITLE
#50 feat: readOnly mode for metric settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "engines": {
     "node": "18 || 20"

--- a/plugins/infrawallet-backend/package.json
+++ b/plugins/infrawallet-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electrolux-oss/plugin-infrawallet-backend",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/plugins/infrawallet-backend/src/service/router.ts
+++ b/plugins/infrawallet-backend/src/service/router.ts
@@ -182,11 +182,25 @@ export async function createRouter(options: RouterOptions): Promise<express.Rout
   });
 
   router.put('/:walletName/metrics_setting', async (request, response) => {
+    const readOnly = config.getOptionalBoolean('infraWallet.settings.readOnly') ?? false;
+
+    if (readOnly) {
+      response.status(403).json({ error: 'API not enabled in read-only mode', status: 403 });
+      return;
+    }
+
     const updatedMetricSetting = await updateOrInsertWalletMetricSetting(database, request.body as MetricSetting);
     response.json({ updated: updatedMetricSetting, status: 200 });
   });
 
   router.delete('/:walletName/metrics_setting', async (request, response) => {
+    const readOnly = config.getOptionalBoolean('infraWallet.settings.readOnly') ?? false;
+
+    if (readOnly) {
+      response.status(403).json({ error: 'API not enabled in read-only mode', status: 403 });
+      return;
+    }
+
     const deletedMetricSetting = await deleteWalletMetricSetting(database, request.body as MetricSetting);
     response.json({ deleted: deletedMetricSetting, status: 200 });
   });

--- a/plugins/infrawallet/config.d.ts
+++ b/plugins/infrawallet/config.d.ts
@@ -6,6 +6,7 @@ export interface Config {
     settings: {
       defaultGroupBy?: string; // if not set, `none` will be used
       defaultShowLastXMonths?: number; // if not set, 3 will be used
+      readOnly?: boolean; // false by default
     };
   };
 }

--- a/plugins/infrawallet/package.json
+++ b/plugins/infrawallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electrolux-oss/plugin-infrawallet",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "backstage": {
     "role": "frontend-plugin"
   },

--- a/plugins/infrawallet/src/components/MetricConfigurationComponent/MetricConfigurationComponent.tsx
+++ b/plugins/infrawallet/src/components/MetricConfigurationComponent/MetricConfigurationComponent.tsx
@@ -1,4 +1,4 @@
-import { alertApiRef, useApi } from '@backstage/core-plugin-api';
+import { alertApiRef, configApiRef, useApi } from '@backstage/core-plugin-api';
 import AddIcon from '@material-ui/icons/Add';
 import CancelIcon from '@material-ui/icons/Close';
 import DeleteIcon from '@material-ui/icons/DeleteOutlined';
@@ -28,11 +28,14 @@ import {
 } from '@mui/x-data-grid';
 
 export const MetricConfigurationComponent: FC<{ wallet?: Wallet }> = ({ wallet }) => {
+  const configApi = useApi(configApiRef);
   const alertApi = useApi(alertApiRef);
   const infraWalletApi = useApi(infraWalletApiRef);
   const [rows, setRows] = useState<GridRowsProp>([]);
   const [metricConfigs, setMetricConfigs] = useState<MetricConfig[]>();
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
+
+  const readOnly = configApi.getOptionalBoolean('infraWallet.settings.readOnly') ?? false;
 
   function EditToolbar() {
     const handleClick = () => {
@@ -136,7 +139,7 @@ export const MetricConfigurationComponent: FC<{ wallet?: Wallet }> = ({ wallet }
       field: 'metric_provider',
       headerName: 'Provider',
       width: 220,
-      editable: true,
+      editable: !readOnly,
       type: 'singleSelect',
       valueOptions: () => {
         const options: ValueOptions[] = [];
@@ -155,7 +158,7 @@ export const MetricConfigurationComponent: FC<{ wallet?: Wallet }> = ({ wallet }
       field: 'config_name',
       headerName: 'ConfigName',
       width: 180,
-      editable: true,
+      editable: !readOnly,
       type: 'singleSelect',
       valueOptions: params => {
         const options: ValueOptions[] = [];
@@ -173,21 +176,24 @@ export const MetricConfigurationComponent: FC<{ wallet?: Wallet }> = ({ wallet }
       field: 'metric_name',
       headerName: 'MetricName',
       width: 220,
-      editable: true,
+      editable: !readOnly,
     },
     {
       field: 'description',
       headerName: 'Description',
       width: 220,
-      editable: true,
+      editable: !readOnly,
     },
     {
       field: 'query',
       headerName: 'Query',
       flex: 1,
-      editable: true,
+      editable: !readOnly,
     },
-    {
+  ];
+
+  if (!readOnly) {
+    columns.push({
       field: 'actions',
       type: 'actions',
       headerName: 'Actions',
@@ -227,8 +233,8 @@ export const MetricConfigurationComponent: FC<{ wallet?: Wallet }> = ({ wallet }
           <GridActionsCellItem icon={<DeleteIcon />} label="Delete" onClick={handleDeleteClick(row)} color="inherit" />,
         ];
       },
-    },
-  ];
+    });
+  }
 
   const getWalletMetricSettings = useCallback(async () => {
     if (wallet) {
@@ -281,7 +287,7 @@ export const MetricConfigurationComponent: FC<{ wallet?: Wallet }> = ({ wallet }
         onRowEditStop={handleRowEditStop}
         processRowUpdate={processRowUpdate}
         slots={{
-          toolbar: EditToolbar as GridSlots['toolbar'],
+          toolbar: readOnly ? null : (EditToolbar as GridSlots['toolbar']),
         }}
       />
     </Box>


### PR DESCRIPTION
If the following configuration is set:

```yaml
infraWallet:
  settings:
    readOnly: true # by default it is false
```

The metric configurations can only be viewed on the settings page (no modifications are allowed). The backend will also respond with 403 if there are direct calls to create, update, or delete a metric.