### PR TITLE
#49 mock client for a metric provider

### DIFF
--- a/plugins/infrawallet-backend/config.d.ts
+++ b/plugins/infrawallet-backend/config.d.ts
@@ -41,6 +41,11 @@ export interface Config {
             tags?: string[];
           },
         ];
+        mock?: [
+          {
+            name: string;
+          },
+        ];
       };
       metricProviders?: {
         datadog?: [
@@ -66,6 +71,11 @@ export interface Config {
              * @visibility secret
              */
             token: string;
+          },
+        ];
+        mock?: [
+          {
+            name: string;
           },
         ];
       };

--- a/plugins/infrawallet-backend/package.json
+++ b/plugins/infrawallet-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electrolux-oss/plugin-infrawallet-backend",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/plugins/infrawallet-backend/src/cost-clients/AwsClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/AwsClient.ts
@@ -9,9 +9,9 @@ import { CacheService, DatabaseService, LoggerService } from '@backstage/backend
 import { Config } from '@backstage/config';
 import { reduce } from 'lodash';
 import moment from 'moment';
+import { getCategoryByServiceName } from '../service/functions';
+import { CostQuery, Report } from '../service/types';
 import { InfraWalletClient } from './InfraWalletClient';
-import { getCategoryByServiceName } from './functions';
-import { CostQuery, Report } from './types';
 
 export class AwsClient extends InfraWalletClient {
   static create(config: Config, database: DatabaseService, cache: CacheService, logger: LoggerService) {

--- a/plugins/infrawallet-backend/src/cost-clients/AzureClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/AzureClient.ts
@@ -5,9 +5,9 @@ import { CacheService, DatabaseService, LoggerService } from '@backstage/backend
 import { Config } from '@backstage/config';
 import { reduce } from 'lodash';
 import moment from 'moment';
+import { getCategoryByServiceName } from '../service/functions';
+import { CostQuery, Report } from '../service/types';
 import { InfraWalletClient } from './InfraWalletClient';
-import { getCategoryByServiceName } from './functions';
-import { CostQuery, Report } from './types';
 
 export class AzureClient extends InfraWalletClient {
   static create(config: Config, database: DatabaseService, cache: CacheService, logger: LoggerService) {

--- a/plugins/infrawallet-backend/src/cost-clients/GCPClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/GCPClient.ts
@@ -2,9 +2,9 @@ import { CacheService, DatabaseService, LoggerService } from '@backstage/backend
 import { Config } from '@backstage/config';
 import { BigQuery } from '@google-cloud/bigquery';
 import { reduce } from 'lodash';
+import { getCategoryByServiceName } from '../service/functions';
+import { CostQuery, Report } from '../service/types';
 import { InfraWalletClient } from './InfraWalletClient';
-import { getCategoryByServiceName } from './functions';
-import { CostQuery, Report } from './types';
 
 export class GCPClient extends InfraWalletClient {
   static create(config: Config, database: DatabaseService, cache: CacheService, logger: LoggerService) {

--- a/plugins/infrawallet-backend/src/cost-clients/InfraWalletClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/InfraWalletClient.ts
@@ -1,7 +1,7 @@
 import { CacheService, DatabaseService, LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
-import { getCategoryMappings, getReportsFromCache, setReportsToCache } from './functions';
-import { ClientResponse, CloudProviderError, CostQuery, Report } from './types';
+import { getCategoryMappings, getReportsFromCache, setReportsToCache } from '../service/functions';
+import { ClientResponse, CloudProviderError, CostQuery, Report } from '../service/types';
 
 export abstract class InfraWalletClient {
   constructor(

--- a/plugins/infrawallet-backend/src/cost-clients/MockClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/MockClient.ts
@@ -1,6 +1,6 @@
 import { promises as fsPromises } from 'fs';
 import moment from 'moment';
-import { CostQuery, Report } from './types';
+import { CostQuery, Report } from '../service/types';
 import * as upath from 'upath';
 import { InfraWalletClient } from './InfraWalletClient';
 import { CacheService, DatabaseService, LoggerService, resolvePackagePath } from '@backstage/backend-plugin-api';

--- a/plugins/infrawallet-backend/src/cost-clients/MockClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/MockClient.ts
@@ -12,7 +12,7 @@ export class MockClient extends InfraWalletClient {
   }
 
   async initCloudClient(config: Config): Promise<any> {
-    console.log('initCloudClient called with config:', config);
+    this.logger.debug(`MockClient.initCloudClient called with config: ${JSON.stringify(config)}`);
 
     return null;
   }
@@ -36,7 +36,7 @@ export class MockClient extends InfraWalletClient {
       const currentDate = moment();
 
       if (endD.isAfter(currentDate)) {
-        console.log('End Date is in the future, adjusting to current date.');
+        this.logger.warn('End Date is in the future, adjusting to current date.');
         endD = currentDate.clone();
         endD.add(1, 'day');
       }
@@ -76,7 +76,7 @@ export class MockClient extends InfraWalletClient {
 
       return processedData;
     } catch (err) {
-      console.error('Error while reading a file', err);
+      this.logger.error('Error while reading a file', err);
       throw err;
     }
   }

--- a/plugins/infrawallet-backend/src/metric-providers/DatadogProvider.ts
+++ b/plugins/infrawallet-backend/src/metric-providers/DatadogProvider.ts
@@ -3,7 +3,7 @@ import { Config } from '@backstage/config';
 import { v1 as datadogApiV1, client as datadogClient } from '@datadog/datadog-api-client';
 import moment from 'moment';
 import { MetricProvider } from './MetricProvider';
-import { Metric, MetricQuery } from './types';
+import { Metric, MetricQuery } from '../service/types';
 
 export class DatadogProvider extends MetricProvider {
   static create(config: Config, database: DatabaseService, cache: CacheService, logger: LoggerService) {

--- a/plugins/infrawallet-backend/src/metric-providers/GrafanaCloudProvider.ts
+++ b/plugins/infrawallet-backend/src/metric-providers/GrafanaCloudProvider.ts
@@ -3,7 +3,7 @@ import { Config } from '@backstage/config';
 import moment from 'moment';
 import fetch from 'node-fetch';
 import { MetricProvider } from './MetricProvider';
-import { Metric, MetricQuery } from './types';
+import { Metric, MetricQuery } from '../service/types';
 
 export class GrafanaCloudProvider extends MetricProvider {
   static create(config: Config, database: DatabaseService, cache: CacheService, logger: LoggerService) {

--- a/plugins/infrawallet-backend/src/metric-providers/MetricProvider.ts
+++ b/plugins/infrawallet-backend/src/metric-providers/MetricProvider.ts
@@ -1,7 +1,7 @@
 import { CacheService, DatabaseService, LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
-import { getMetricsFromCache, setMetricsToCache } from './functions';
-import { CloudProviderError, Metric, MetricQuery, MetricSetting, MetricResponse } from './types';
+import { getMetricsFromCache, setMetricsToCache } from '../service/functions';
+import { CloudProviderError, Metric, MetricQuery, MetricSetting, MetricResponse } from '../service/types';
 
 export abstract class MetricProvider {
   constructor(

--- a/plugins/infrawallet-backend/src/metric-providers/MockProvider.ts
+++ b/plugins/infrawallet-backend/src/metric-providers/MockProvider.ts
@@ -1,0 +1,54 @@
+import { CacheService, DatabaseService, LoggerService } from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config';
+import moment from 'moment';
+import { MetricProvider } from './MetricProvider';
+import { Metric, MetricQuery } from '../service/types';
+
+export class MockProvider extends MetricProvider {
+  static create(config: Config, database: DatabaseService, cache: CacheService, logger: LoggerService) {
+    return new MockProvider('Mock', config, database, cache, logger);
+  }
+
+  async initProviderClient(_config: Config): Promise<any> {
+    // for now we don't need to use Grafana Cloud SDK
+    return null;
+  }
+
+  async fetchMetrics(_metricProviderConfig: Config, _client: any, _query: MetricQuery): Promise<any> {
+    return null;
+  }
+
+  async transformMetricData(
+    _metricProviderConfig: Config,
+    query: MetricQuery,
+    _metricResponse: any,
+  ): Promise<Metric[]> {
+    const transformedData = [];
+
+    const metricName = query.name as string;
+    let mockSettings: { min?: number; max?: number } = {};
+    try {
+      mockSettings = JSON.parse(query.query as string);
+    } catch (e) {
+      // nothing needs to be done
+    }
+    const minValue = mockSettings.min ?? 0;
+    const maxValue = mockSettings.max ?? 1000;
+    const metric: Metric = {
+      id: metricName,
+      provider: this.providerName,
+      name: metricName,
+      reports: {},
+    };
+
+    let cursor = moment(parseInt(query.startTime, 10));
+    while (cursor <= moment(parseInt(query.endTime, 10))) {
+      const period = cursor.format(query.granularity === 'daily' ? 'YYYY-MM-DD' : 'YYYY-MM');
+      metric.reports[period] = Math.floor(Math.random() * (maxValue - minValue) + minValue);
+      cursor = cursor.add(1, query.granularity === 'daily' ? 'days' : 'months');
+    }
+
+    transformedData.push(metric);
+    return transformedData;
+  }
+}

--- a/plugins/infrawallet-backend/src/service/consts.ts
+++ b/plugins/infrawallet-backend/src/service/consts.ts
@@ -1,9 +1,10 @@
-import { AwsClient } from './AwsClient';
-import { AzureClient } from './AzureClient';
-import { DatadogProvider } from './DatadogProvider';
-import { GCPClient } from './GCPClient';
-import { GrafanaCloudProvider } from './GrafanaCloudProvider';
-import { MockClient } from './MockClient';
+import { AwsClient } from '../cost-clients/AwsClient';
+import { AzureClient } from '../cost-clients/AzureClient';
+import { GCPClient } from '../cost-clients/GCPClient';
+import { DatadogProvider } from '../metric-providers/DatadogProvider';
+import { GrafanaCloudProvider } from '../metric-providers/GrafanaCloudProvider';
+import { MockProvider } from '../metric-providers/MockProvider';
+import { MockClient } from '../cost-clients/MockClient';
 
 export const COST_CLIENT_MAPPINGS: {
   [provider: string]: any;
@@ -19,4 +20,5 @@ export const METRIC_PROVIDER_MAPPINGS: {
 } = {
   datadog: DatadogProvider,
   grafanacloud: GrafanaCloudProvider,
+  mock: MockProvider,
 };

--- a/plugins/infrawallet-backend/src/service/functions.ts
+++ b/plugins/infrawallet-backend/src/service/functions.ts
@@ -95,7 +95,10 @@ export async function getMetricsFromCache(
     query.startTime,
     query.endTime,
   ].join('_');
-  const cachedMetrics = (await cache.get(cacheKey)) as Metric[] | undefined;
+  const crypto = require('crypto');
+  const cachedMetrics = (await cache.get(crypto.createHash('md5').update(cacheKey).digest('hex'))) as
+    | Metric[]
+    | undefined;
   return cachedMetrics;
 }
 

--- a/plugins/infrawallet-backend/src/service/router.ts
+++ b/plugins/infrawallet-backend/src/service/router.ts
@@ -9,8 +9,8 @@ import {
   getWalletMetricSettings,
   updateOrInsertWalletMetricSetting,
 } from '../controllers/MetricSettingController';
-import { InfraWalletClient } from './InfraWalletClient';
-import { MetricProvider } from './MetricProvider';
+import { InfraWalletClient } from '../cost-clients/InfraWalletClient';
+import { MetricProvider } from '../metric-providers/MetricProvider';
 import { COST_CLIENT_MAPPINGS, METRIC_PROVIDER_MAPPINGS } from './consts';
 import { CloudProviderError, Metric, MetricSetting, Report } from './types';
 

--- a/plugins/infrawallet/package.json
+++ b/plugins/infrawallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electrolux-oss/plugin-infrawallet",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
This PR provides a mock client for business metrics. In this way, developers do not need to configure Datadog or GrafanaCloud integrations to display business metrics.