### PR TITLE
#60 feat: support yaxis grouping for metrics

### DIFF
--- a/plugins/infrawallet-backend/migrations/20240906142013_add-metric-axis-groupping.js
+++ b/plugins/infrawallet-backend/migrations/20240906142013_add-metric-axis-groupping.js
@@ -4,7 +4,7 @@
  */
 exports.up = async function up(knex) {
   await knex.schema.table('business_metrics', table => {
-    table.string('yaxis_group').comment('Metrics using the same value in this column will share the same yaxis label');
+    table.string('group').comment('Metrics using the same value in this column will share the same yaxis label');
   });
 };
 
@@ -14,6 +14,6 @@ exports.up = async function up(knex) {
  */
 exports.down = async function down(knex) {
   await knex.schema.table('business_metrics', table => {
-    table.dropColumn('yaxis_group');
+    table.dropColumn('group');
   });
 };

--- a/plugins/infrawallet-backend/migrations/20240906142013_add-metric-axis-groupping.js
+++ b/plugins/infrawallet-backend/migrations/20240906142013_add-metric-axis-groupping.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.table('business_metrics', table => {
+    table.string('yaxis_group').comment('Metrics using the same value in this column will share the same yaxis label');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.table('business_metrics', table => {
+    table.dropColumn('yaxis_group');
+  });
+};

--- a/plugins/infrawallet-backend/src/metric-providers/MetricProvider.ts
+++ b/plugins/infrawallet-backend/src/metric-providers/MetricProvider.ts
@@ -63,7 +63,10 @@ export abstract class MetricProvider {
             if (cachedMetrics) {
               this.logger.debug(`${this.providerName}/${configName}/${fullQuery.name} metrics from cache`);
               cachedMetrics.map(m => {
-                results.push(m);
+                results.push({
+                  yaxis_group: metric.yaxis_group, // add yaxis_group info to the metric
+                  ...m,
+                });
               });
               return;
             }
@@ -82,7 +85,10 @@ export abstract class MetricProvider {
             );
 
             transformedMetrics.map((value: any) => {
-              results.push(value);
+              results.push({
+                yaxis_group: metric.yaxis_group, // add yaxis_group info to the metric
+                ...value,
+              });
             });
           } catch (e) {
             this.logger.error(e);

--- a/plugins/infrawallet-backend/src/metric-providers/MetricProvider.ts
+++ b/plugins/infrawallet-backend/src/metric-providers/MetricProvider.ts
@@ -64,7 +64,7 @@ export abstract class MetricProvider {
               this.logger.debug(`${this.providerName}/${configName}/${fullQuery.name} metrics from cache`);
               cachedMetrics.map(m => {
                 results.push({
-                  yaxis_group: metric.yaxis_group, // add yaxis_group info to the metric
+                  group: metric.group, // add group info to the metric
                   ...m,
                 });
               });
@@ -86,7 +86,7 @@ export abstract class MetricProvider {
 
             transformedMetrics.map((value: any) => {
               results.push({
-                yaxis_group: metric.yaxis_group, // add yaxis_group info to the metric
+                group: metric.group, // add group info to the metric
                 ...value,
               });
             });

--- a/plugins/infrawallet-backend/src/service/types.ts
+++ b/plugins/infrawallet-backend/src/service/types.ts
@@ -64,6 +64,7 @@ export type MetricQuery = {
 export type Metric = {
   id: string;
   provider: string;
+  yaxis_group?: string;
   name: string;
   reports: {
     [period: string]: number;
@@ -82,6 +83,7 @@ export type MetricSetting = {
   config_name: string;
   metric_name: string;
   description?: string;
+  yaxis_group?: string;
   query: string;
 };
 

--- a/plugins/infrawallet-backend/src/service/types.ts
+++ b/plugins/infrawallet-backend/src/service/types.ts
@@ -64,7 +64,7 @@ export type MetricQuery = {
 export type Metric = {
   id: string;
   provider: string;
-  yaxis_group?: string;
+  group?: string;
   name: string;
   reports: {
     [period: string]: number;
@@ -83,7 +83,7 @@ export type MetricSetting = {
   config_name: string;
   metric_name: string;
   description?: string;
-  yaxis_group?: string;
+  group?: string;
   query: string;
 };
 

--- a/plugins/infrawallet/src/api/types.ts
+++ b/plugins/infrawallet/src/api/types.ts
@@ -67,6 +67,7 @@ export type MetricSetting = {
   config_name: string;
   metric_name: string;
   description?: string;
+  yaxis_group?: string;
   query: string;
 };
 

--- a/plugins/infrawallet/src/api/types.ts
+++ b/plugins/infrawallet/src/api/types.ts
@@ -67,7 +67,7 @@ export type MetricSetting = {
   config_name: string;
   metric_name: string;
   description?: string;
-  yaxis_group?: string;
+  group?: string;
   query: string;
 };
 

--- a/plugins/infrawallet/src/components/ColumnsChartComponent/ColumnsChartComponent.tsx
+++ b/plugins/infrawallet/src/components/ColumnsChartComponent/ColumnsChartComponent.tsx
@@ -157,28 +157,59 @@ export const ColumnsChartComponent: FC<ColumnsChartComponentProps> = ({
     ];
 
     if (metrics && showMetrics) {
+      const metricYAxisGroups: any = {};
       metrics.forEach(metric => {
         strokeWidth.push(3);
         seriesResult.push(metric);
-        yaxisResult.push({
-          seriesName: [metric.name],
-          decimalsInFloat: 2,
-          opposite: true,
-          title: {
-            text: metric.name,
-          },
-          labels: {
-            formatter: (value: number) => {
-              if (typeof value !== 'number' || isNaN(value)) {
-                return '';
-              }
-              return humanFormat(value, {
-                scale: scale,
-                separator: '',
-              });
+
+        if (metric.group) {
+          if (!metricYAxisGroups[metric.group]) {
+            metricYAxisGroups[metric.group] = {
+              seriesName: [metric.name],
+              decimalsInFloat: 2,
+              opposite: true,
+              title: {
+                text: metric.group,
+              },
+              labels: {
+                formatter: (value: number) => {
+                  if (typeof value !== 'number' || isNaN(value)) {
+                    return '';
+                  }
+                  return humanFormat(value, {
+                    scale: scale,
+                    separator: '',
+                  });
+                },
+              },
+            };
+          } else {
+            metricYAxisGroups[metric.group].seriesName.push(metric.name);
+          }
+        } else {
+          yaxisResult.push({
+            seriesName: [metric.name],
+            decimalsInFloat: 2,
+            opposite: true,
+            title: {
+              text: metric.name,
             },
-          },
-        });
+            labels: {
+              formatter: (value: number) => {
+                if (typeof value !== 'number' || isNaN(value)) {
+                  return '';
+                }
+                return humanFormat(value, {
+                  scale: scale,
+                  separator: '',
+                });
+              },
+            },
+          });
+        }
+      });
+      Object.values(metricYAxisGroups).forEach((group: any) => {
+        yaxisResult.push(group);
       });
     }
 

--- a/plugins/infrawallet/src/components/ColumnsChartComponent/ColumnsChartComponent.tsx
+++ b/plugins/infrawallet/src/components/ColumnsChartComponent/ColumnsChartComponent.tsx
@@ -158,14 +158,14 @@ export const ColumnsChartComponent: FC<ColumnsChartComponentProps> = ({
     ];
 
     if (metrics && showMetrics) {
-      const metricYAxisGroups: any = {};
+      const metricGroups: any = {};
       metrics.forEach(metric => {
         strokeWidth.push(3);
         seriesResult.push(metric);
 
         if (metric.group) {
-          if (!metricYAxisGroups[metric.group]) {
-            metricYAxisGroups[metric.group] = {
+          if (!metricGroups[metric.group]) {
+            metricGroups[metric.group] = {
               seriesName: [metric.name],
               decimalsInFloat: 2,
               opposite: true,
@@ -179,7 +179,7 @@ export const ColumnsChartComponent: FC<ColumnsChartComponentProps> = ({
             };
           } else {
             // yaxis already exists, add the series to the existing one
-            metricYAxisGroups[metric.group].seriesName.push(metric.name);
+            metricGroups[metric.group].seriesName.push(metric.name);
           }
         } else {
           // the metric does not have a group, create a separate yaxis for it
@@ -197,7 +197,7 @@ export const ColumnsChartComponent: FC<ColumnsChartComponentProps> = ({
           });
         }
       });
-      Object.values(metricYAxisGroups).forEach((group: any) => {
+      Object.values(metricGroups).forEach((group: any) => {
         yaxisResult.push(group);
       });
     }

--- a/plugins/infrawallet/src/components/ColumnsChartComponent/ColumnsChartComponent.tsx
+++ b/plugins/infrawallet/src/components/ColumnsChartComponent/ColumnsChartComponent.tsx
@@ -131,10 +131,19 @@ export const ColumnsChartComponent: FC<ColumnsChartComponentProps> = ({
       };
 
   const initChartCallback = useCallback(async () => {
+    const labelFormatter = (value: number): string => {
+      const scale = humanFormat.Scale.create(['', 'K', 'M', 'B'], 1000);
+      if (typeof value !== 'number' || isNaN(value)) {
+        return '';
+      }
+      return `$${humanFormat(value, {
+        scale: scale,
+        separator: '',
+      })}`;
+    };
+
     const strokeWidth = Array<number>(series.length).fill(0);
     const seriesResult = series.map(s => s);
-    // init a scale here as well, it seems that adding the predefined customScale as a dependency is buggy
-    const scale = humanFormat.Scale.create(['', 'K', 'M', 'B'], 1000);
     const yaxisResult: any[] = [
       {
         seriesName: series.map(s => s.name),
@@ -143,15 +152,7 @@ export const ColumnsChartComponent: FC<ColumnsChartComponentProps> = ({
           text: 'Costs in USD',
         },
         labels: {
-          formatter: (value: number) => {
-            if (typeof value !== 'number' || isNaN(value)) {
-              return '';
-            }
-            return `$${humanFormat(value, {
-              scale: scale,
-              separator: '',
-            })}`;
-          },
+          formatter: labelFormatter,
         },
       },
     ];
@@ -168,42 +169,30 @@ export const ColumnsChartComponent: FC<ColumnsChartComponentProps> = ({
               seriesName: [metric.name],
               decimalsInFloat: 2,
               opposite: true,
+              forceNiceScale: true,
               title: {
                 text: metric.group,
               },
               labels: {
-                formatter: (value: number) => {
-                  if (typeof value !== 'number' || isNaN(value)) {
-                    return '';
-                  }
-                  return humanFormat(value, {
-                    scale: scale,
-                    separator: '',
-                  });
-                },
+                formatter: labelFormatter,
               },
             };
           } else {
+            // yaxis already exists, add the series to the existing one
             metricYAxisGroups[metric.group].seriesName.push(metric.name);
           }
         } else {
+          // the metric does not have a group, create a separate yaxis for it
           yaxisResult.push({
             seriesName: [metric.name],
             decimalsInFloat: 2,
             opposite: true,
+            forceNiceScale: true,
             title: {
               text: metric.name,
             },
             labels: {
-              formatter: (value: number) => {
-                if (typeof value !== 'number' || isNaN(value)) {
-                  return '';
-                }
-                return humanFormat(value, {
-                  scale: scale,
-                  separator: '',
-                });
-              },
+              formatter: labelFormatter,
             },
           });
         }

--- a/plugins/infrawallet/src/components/ColumnsChartComponent/ColumnsChartComponent.tsx
+++ b/plugins/infrawallet/src/components/ColumnsChartComponent/ColumnsChartComponent.tsx
@@ -40,7 +40,7 @@ export const ColumnsChartComponent: FC<ColumnsChartComponentProps> = ({
     },
   });
   const classes = useStyles();
-  const [showMetrics, setShowMetrics] = useState<boolean>(true);
+  const [showMetrics, setShowMetrics] = useState<boolean>(false);
   const [seriesArray, setSeriesArray] = useState<any[]>([]);
   const [yaxisArray, setYaxisArray] = useState<any[]>([]);
   const [strokeWidthArray, setStrokeWidthArray] = useState<number[]>([]);

--- a/plugins/infrawallet/src/components/MetricConfigurationComponent/MetricConfigurationComponent.tsx
+++ b/plugins/infrawallet/src/components/MetricConfigurationComponent/MetricConfigurationComponent.tsx
@@ -49,6 +49,7 @@ export const MetricConfigurationComponent: FC<{ wallet?: Wallet }> = ({ wallet }
           config_name: '',
           metric_name: '',
           description: '',
+          yaxis_group: '',
           query: '',
           isNew: true,
         },
@@ -182,6 +183,12 @@ export const MetricConfigurationComponent: FC<{ wallet?: Wallet }> = ({ wallet }
       field: 'description',
       headerName: 'Description',
       width: 220,
+      editable: !readOnly,
+    },
+    {
+      field: 'yaxis_group',
+      headerName: 'YAxisGroup',
+      width: 100,
       editable: !readOnly,
     },
     {

--- a/plugins/infrawallet/src/components/MetricConfigurationComponent/MetricConfigurationComponent.tsx
+++ b/plugins/infrawallet/src/components/MetricConfigurationComponent/MetricConfigurationComponent.tsx
@@ -49,7 +49,7 @@ export const MetricConfigurationComponent: FC<{ wallet?: Wallet }> = ({ wallet }
           config_name: '',
           metric_name: '',
           description: '',
-          yaxis_group: '',
+          group: '',
           query: '',
           isNew: true,
         },
@@ -186,7 +186,7 @@ export const MetricConfigurationComponent: FC<{ wallet?: Wallet }> = ({ wallet }
       editable: !readOnly,
     },
     {
-      field: 'yaxis_group',
+      field: 'group',
       headerName: 'Group',
       width: 100,
       editable: !readOnly,

--- a/plugins/infrawallet/src/components/MetricConfigurationComponent/MetricConfigurationComponent.tsx
+++ b/plugins/infrawallet/src/components/MetricConfigurationComponent/MetricConfigurationComponent.tsx
@@ -187,7 +187,7 @@ export const MetricConfigurationComponent: FC<{ wallet?: Wallet }> = ({ wallet }
     },
     {
       field: 'yaxis_group',
-      headerName: 'YAxisGroup',
+      headerName: 'Group',
       width: 100,
       editable: !readOnly,
     },

--- a/plugins/infrawallet/src/components/ReportsComponent/ReportsComponent.tsx
+++ b/plugins/infrawallet/src/components/ReportsComponent/ReportsComponent.tsx
@@ -204,7 +204,7 @@ export const ReportsComponent = (props: ReportsComponentProps) => {
                 }))}
                 metrics={metrics.map((item: any) => ({
                   name: item.name,
-                  group: item.yaxis_group,
+                  group: item.group,
                   type: 'line',
                   data: rearrangeData(item, periods),
                 }))}

--- a/plugins/infrawallet/src/components/ReportsComponent/ReportsComponent.tsx
+++ b/plugins/infrawallet/src/components/ReportsComponent/ReportsComponent.tsx
@@ -203,7 +203,7 @@ export const ReportsComponent = (props: ReportsComponentProps) => {
                   data: rearrangeData(item, periods),
                 }))}
                 metrics={metrics.map((item: any) => ({
-                  name: item.id,
+                  name: item.name,
                   group: item.yaxis_group,
                   type: 'line',
                   data: rearrangeData(item, periods),

--- a/plugins/infrawallet/src/components/ReportsComponent/ReportsComponent.tsx
+++ b/plugins/infrawallet/src/components/ReportsComponent/ReportsComponent.tsx
@@ -204,6 +204,7 @@ export const ReportsComponent = (props: ReportsComponentProps) => {
                 }))}
                 metrics={metrics.map((item: any) => ({
                   name: item.id,
+                  group: item.yaxis_group,
                   type: 'line',
                   data: rearrangeData(item, periods),
                 }))}

--- a/plugins/infrawallet/src/components/types.ts
+++ b/plugins/infrawallet/src/components/types.ts
@@ -40,7 +40,7 @@ export type ColumnsChartComponentProps = {
   granularitySetter: any;
   categories: any[];
   series: Array<{ name: string; data: any[] }>;
-  metrics?: Array<{ name: string; data: any[] }>;
+  metrics?: Array<{ name: string; group?: string; data: any[] }>;
   height?: number;
   thumbnail?: boolean;
   dataPointSelectionHandler?: (event: any, chartContext: any, config: any) => void;


### PR DESCRIPTION
This PR addresses #60 and enables users to group business metrics.

When creating a metric, users can assign a value under the `Group` column. The value is optional. If it is not set, the metric uses a separate y-axis. If it is set, all the metrics that use the same value, share the same y-axis. 

<img width="946" alt="image" src="https://github.com/user-attachments/assets/cfb831cc-5a72-4abc-9be3-a12398b9875b">

<img width="1209" alt="image" src="https://github.com/user-attachments/assets/5e8c2113-3e7a-47b8-8738-5ca760fcfb8e">
