### PR TITLE
initial commit for EntityInfraWalletCard

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -191,6 +191,21 @@ import { InfraWalletPage } from '@electrolux-oss/plugin-infrawallet';
 </FlatRoutes>
 ...
 ```
+modify `packages/app/src/components/catalog/EntityPage.tsx` and add the following code
+```ts
+...
+import {EntityInfraWalletCard, isInfraWalletAvailable } from '@electrolux-oss/plugin-infrawallet';
+...
+
+    <EntitySwitch>
+      <EntitySwitch.Case if={isInfraWalletAvailable}>
+        <Grid item md={6}>
+          <EntityInfraWalletCard />
+        </Grid>
+      </EntitySwitch.Case>
+    </EntitySwitch>
+...
+```
 
 2. add InfraWallet backend
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -191,7 +191,9 @@ import { InfraWalletPage } from '@electrolux-oss/plugin-infrawallet';
 </FlatRoutes>
 ...
 ```
+
 modify `packages/app/src/components/catalog/EntityPage.tsx` and add the following code
+
 ```ts
 ...
 import {EntityInfraWalletCard, isInfraWalletAvailable } from '@electrolux-oss/plugin-infrawallet';

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     ]
   },
   "dependencies": {
+    "@backstage/plugin-catalog-react": "^1.13.0",
     "@hookform/resolvers": "^3.3.2",
     "react-redux": "^9.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     ]
   },
   "dependencies": {
+    "@backstage/catalog-model": "^1.7.0",
     "@backstage/plugin-catalog-react": "^1.13.0",
     "@hookform/resolvers": "^3.3.2",
     "react-redux": "^9.1.0"

--- a/plugins/infrawallet-backend/src/service/functions.ts
+++ b/plugins/infrawallet-backend/src/service/functions.ts
@@ -206,3 +206,35 @@ export async function setMetricsToCache(
     ttl: ttl ?? 60 * 60 * 2 * 1000,
   }); // cache for 2 hours by default
 }
+
+
+export function parseFilters(filters: string): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+
+  if (!filters || filters[0] !== '(' || filters[filters.length - 1] !== ')') {
+    return result;
+  }
+
+  const filterString = filters.slice(1, -1);
+  if (!filterString) {
+    return result;
+  }
+
+  const keyValuePairs = filterString.split(',').map(pair => pair.trim());
+
+  keyValuePairs.forEach(pair => {
+    const [key, value] = pair.split(':').map(s => s.trim());
+    if (key && value) {
+      if (value.startsWith('(') && value.endsWith(')')) {
+        // multiple values
+        const values = value.slice(1, -1).split('|').map(v => v.trim());
+        result[key] = values;
+      } else {
+        // single value
+        result[key] = [value];
+      }
+    }
+  });
+
+  return result;
+}

--- a/plugins/infrawallet-backend/src/service/functions.ts
+++ b/plugins/infrawallet-backend/src/service/functions.ts
@@ -207,7 +207,6 @@ export async function setMetricsToCache(
   }); // cache for 2 hours by default
 }
 
-
 export function parseFilters(filters: string): Record<string, string[]> {
   const result: Record<string, string[]> = {};
 
@@ -227,7 +226,10 @@ export function parseFilters(filters: string): Record<string, string[]> {
     if (key && value) {
       if (value.startsWith('(') && value.endsWith(')')) {
         // multiple values
-        const values = value.slice(1, -1).split('|').map(v => v.trim());
+        const values = value
+          .slice(1, -1)
+          .split('|')
+          .map(v => v.trim());
         result[key] = values;
       } else {
         // single value

--- a/plugins/infrawallet-backend/src/service/router.ts
+++ b/plugins/infrawallet-backend/src/service/router.ts
@@ -13,7 +13,6 @@ import { InfraWalletClient } from '../cost-clients/InfraWalletClient';
 import { MetricProvider } from '../metric-providers/MetricProvider';
 import { CategoryMappingService } from './CategoryMappingService';
 import { COST_CLIENT_MAPPINGS, METRIC_PROVIDER_MAPPINGS } from './consts';
-import { parseTags, tagsToString } from './functions';
 import { CloudProviderError, Metric, MetricSetting, Report, Tag } from './types';
 import { parseTags, tagsToString, parseFilters } from './functions';
 

--- a/plugins/infrawallet-backend/src/service/router.ts
+++ b/plugins/infrawallet-backend/src/service/router.ts
@@ -127,8 +127,6 @@ export async function createRouter(options: RouterOptions): Promise<express.Rout
       });
     });
 
-
-
     if (errors.length > 0) {
       response.status(207).json({ data: filteredResults, errors: errors, status: 207 });
     } else {

--- a/plugins/infrawallet-backend/src/service/router.ts
+++ b/plugins/infrawallet-backend/src/service/router.ts
@@ -15,6 +15,7 @@ import { CategoryMappingService } from './CategoryMappingService';
 import { COST_CLIENT_MAPPINGS, METRIC_PROVIDER_MAPPINGS } from './consts';
 import { parseTags, tagsToString } from './functions';
 import { CloudProviderError, Metric, MetricSetting, Report, Tag } from './types';
+import { parseTags, tagsToString, parseFilters } from './functions';
 
 export interface RouterOptions {
   logger: LoggerService;
@@ -114,10 +115,24 @@ export async function createRouter(options: RouterOptions): Promise<express.Rout
 
     await Promise.all(promises);
 
+    const parsedFilters = parseFilters(filters);
+
+    const filteredResults = results.filter(report => {
+      return Object.entries(parsedFilters).every(([key, values]) => {
+        const reportValue = report[key];
+        if (typeof reportValue !== 'string') {
+          return false;
+        }
+        return values.includes(reportValue);
+      });
+    });
+
+
+
     if (errors.length > 0) {
-      response.status(207).json({ data: results, errors: errors, status: 207 });
+      response.status(207).json({ data: filteredResults, errors: errors, status: 207 });
     } else {
-      response.json({ data: results, errors: errors, status: 200 });
+      response.json({ data: filteredResults, errors: errors, status: 200 });
     }
   });
 

--- a/plugins/infrawallet-backend/src/service/types.ts
+++ b/plugins/infrawallet-backend/src/service/types.ts
@@ -31,6 +31,7 @@ export type Report = {
   reports: {
     [period: string]: number;
   };
+  [key: string]: string | number | { [period: string]: number } | undefined;
 };
 
 export type Tag = {

--- a/plugins/infrawallet/package.json
+++ b/plugins/infrawallet/package.json
@@ -36,6 +36,7 @@
     "@backstage/config": "^1.2.0",
     "@backstage/core-components": "^0.14.7",
     "@backstage/core-plugin-api": "^1.9.2",
+    "@backstage/plugin-catalog-react": "^1.13.0",
     "@backstage/theme": "^0.5.4",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",

--- a/plugins/infrawallet/package.json
+++ b/plugins/infrawallet/package.json
@@ -55,7 +55,9 @@
     "moment": "2.29.4",
     "mui-modal-provider": "2.2.0",
     "node-fetch": "^2.6.7",
+    "query-string": "7.0.0",
     "react-apexcharts": "1.4.1",
+    "recharts": "^2.12.7",
     "uuid": "10.0.0"
   },
   "devDependencies": {

--- a/plugins/infrawallet/package.json
+++ b/plugins/infrawallet/package.json
@@ -33,6 +33,7 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
+    "@backstage/catalog-model": "^1.7.0",
     "@backstage/config": "^1.2.0",
     "@backstage/core-components": "^0.14.7",
     "@backstage/core-plugin-api": "^1.9.2",

--- a/plugins/infrawallet/src/api/InfraWalletApiClient.ts
+++ b/plugins/infrawallet/src/api/InfraWalletApiClient.ts
@@ -1,6 +1,7 @@
 import { ConfigApi, IdentityApi } from '@backstage/core-plugin-api';
 import fetch from 'node-fetch';
 import { InfraWalletApi } from './InfraWalletApi';
+import { stringify } from 'query-string';
 import {
   CostReportsResponse,
   GetWalletResponse,
@@ -58,13 +59,24 @@ export class InfraWalletApiClient implements InfraWalletApi {
     groups: string,
     granularity: string,
     startTime: Date,
-    endTime: Date,
+    endTime: Date
   ): Promise<CostReportsResponse> {
     const tagsString = tagsToString(tags);
-    const url = `api/infrawallet/reports?&filters=${filters}&tags=${tagsString}&groups=${groups}&granularity=${granularity}&startTime=${startTime.getTime()}&endTime=${endTime.getTime()}`;
+    const queryParams = {
+      filters,
+      tags: tagsString,
+      groups,
+      granularity,
+      startTime: startTime.getTime(),
+      endTime: endTime.getTime(),
+    };
+    const queryString = stringify(queryParams);
+    const url = `api/infrawallet/reports?${queryString}`;
+
+    console.log(`Requesting cost reports with URL: ${url}`);
+
     return await this.request(url);
   }
-
   async getTagKeys(provider: string, startTime: Date, endTime: Date): Promise<TagResponse> {
     const url = `api/infrawallet/tag-keys?provider=${provider}&startTime=${startTime.getTime()}&endTime=${endTime.getTime()}`;
     return await this.request(url);

--- a/plugins/infrawallet/src/api/InfraWalletApiClient.ts
+++ b/plugins/infrawallet/src/api/InfraWalletApiClient.ts
@@ -73,7 +73,6 @@ export class InfraWalletApiClient implements InfraWalletApi {
     const queryString = stringify(queryParams);
     const url = `api/infrawallet/reports?${queryString}`;
 
-    console.log(`Requesting cost reports with URL: ${url}`);
 
     return await this.request(url);
   }

--- a/plugins/infrawallet/src/api/InfraWalletApiClient.ts
+++ b/plugins/infrawallet/src/api/InfraWalletApiClient.ts
@@ -59,7 +59,7 @@ export class InfraWalletApiClient implements InfraWalletApi {
     groups: string,
     granularity: string,
     startTime: Date,
-    endTime: Date
+    endTime: Date,
   ): Promise<CostReportsResponse> {
     const tagsString = tagsToString(tags);
     const queryParams = {
@@ -72,7 +72,6 @@ export class InfraWalletApiClient implements InfraWalletApi {
     };
     const queryString = stringify(queryParams);
     const url = `api/infrawallet/reports?${queryString}`;
-
 
     return await this.request(url);
   }

--- a/plugins/infrawallet/src/components/EntityInfraWalletCard/EntityInfraWalletCard.tsx
+++ b/plugins/infrawallet/src/components/EntityInfraWalletCard/EntityInfraWalletCard.tsx
@@ -1,0 +1,135 @@
+import React, { useState, useEffect } from 'react';
+import { Progress, InfoCard } from '@backstage/core-components';
+import { Alert } from '@material-ui/lab';
+import { useApi } from '@backstage/core-plugin-api';
+import { infraWalletApiRef } from '../../api/InfraWalletApi';
+import { useEntity, catalogApiRef } from '@backstage/plugin-catalog-react';
+import { Report, Tag } from '../../api/types';
+import { Card, CardContent, Typography } from '@material-ui/core';
+
+export const EntityInfraWalletCard = () => {
+  const { entity } = useEntity();
+  const infrawalletApi = useApi(infraWalletApiRef);
+  const catalogApi = useApi(catalogApiRef);
+
+  const [gcpProjectIds, setGcpProjectIds] = useState<string[]>([]);
+  const [costData, setCostData] = useState<Report[] | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [debugInfo, setDebugInfo] = useState<string>('');
+
+  useEffect(() => {
+    const fetchGcpProjectIds = async () => {
+      try {
+        let projectIds: string[] = [];
+
+        const annotationGcpProjectIds = entity.metadata.annotations?.['infrawallet.io/gcp-project-ids'];
+        if (annotationGcpProjectIds) {
+          projectIds = annotationGcpProjectIds.split(',').map(id => id.trim());
+        }
+
+        const dependsOnRelations = entity.relations?.filter(rel => rel.type === 'dependsOn') || [];
+        const targetEntityRefs = dependsOnRelations.map(rel => rel.targetRef);
+
+        const targetEntitiesPromises = targetEntityRefs.map(ref => catalogApi.getEntityByRef(ref));
+        const targetEntities = await Promise.all(targetEntitiesPromises);
+
+        for (const targetEntity of targetEntities) {
+          if (
+            targetEntity?.kind.toLocaleLowerCase('en-US') === 'resource' &&
+            targetEntity.spec?.type === 'gcp-project'
+          ) {
+            const gcpProjectId = targetEntity.metadata.name;
+            projectIds.push(gcpProjectId);
+          }
+        }
+
+        setGcpProjectIds(projectIds);
+        setDebugInfo(prev => prev + `Resolved GCP Project IDs: ${projectIds.join(', ')}\n`);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Unknown error occurred');
+      }
+    };
+
+    fetchGcpProjectIds();
+  }, [entity, catalogApi]);
+
+  useEffect(() => {
+    const fetchCostData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        if (gcpProjectIds.length === 0) {
+          setCostData(null);
+          setLoading(false);
+          return;
+        }
+
+        const filters = `(${gcpProjectIds.map(id => `gcp_project_id=${id}`).join(' OR ')})`;
+        const tags: Tag[] = [];
+        const groups = '';
+        const granularity = 'monthly';
+        const endTime = new Date();
+        const startTime = new Date();
+        startTime.setMonth(endTime.getMonth() - 1);
+
+        setDebugInfo(prev => prev + `Filters: ${filters}\n`);
+
+        const costReportsResponse = await infrawalletApi.getCostReports(
+          filters,
+          tags,
+          groups,
+          granularity,
+          startTime,
+          endTime,
+        );
+
+        if (costReportsResponse.status !== 200) {
+          throw new Error('Failed to fetch cost reports');
+        }
+
+        setCostData(costReportsResponse.data || null);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Unknown error occurred');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCostData();
+  }, [gcpProjectIds, infrawalletApi]);
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  if (error) {
+    return <Alert severity="error">{error}</Alert>;
+  }
+
+  if (!costData || costData.length === 0) {
+    return <Alert severity="info">No cost data available for this entity.</Alert>;
+  }
+
+  return (
+    <InfoCard title="Cost Information">
+      <Typography variant="body2">
+        <pre>{debugInfo}</pre>
+      </Typography>
+      {costData.map((report: Report) => (
+        <Card variant="outlined" key={report.id} style={{ marginBottom: '16px' }}>
+          <CardContent>
+            <Typography variant="h6">Project ID: {report.id}</Typography>
+            <Typography variant="body2">
+              {Object.entries(report.reports).map(([period, cost]) => (
+                <div key={period}>
+                  {period}: ${Number(cost).toFixed(2)}
+                </div>
+              ))}
+            </Typography>
+          </CardContent>
+        </Card>
+      ))}
+    </InfoCard>
+  );
+};

--- a/plugins/infrawallet/src/components/EntityInfraWalletCard/EntityInfraWalletCard.tsx
+++ b/plugins/infrawallet/src/components/EntityInfraWalletCard/EntityInfraWalletCard.tsx
@@ -3,77 +3,158 @@ import { Progress, InfoCard } from '@backstage/core-components';
 import { Alert } from '@material-ui/lab';
 import { useApi } from '@backstage/core-plugin-api';
 import { infraWalletApiRef } from '../../api/InfraWalletApi';
-import { useEntity, catalogApiRef } from '@backstage/plugin-catalog-react';
+import { useEntity } from '@backstage/plugin-catalog-react';
 import { Report, Tag } from '../../api/types';
-import { Card, CardContent, Typography } from '@material-ui/core';
+import {
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tabs,
+  Tab,
+  Box,
+} from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Legend,
+} from 'recharts';
+
+const useStyles = makeStyles({
+  increase: {
+    color: '#ae2e24',
+    backgroundColor: '#ffeceb',
+    borderRadius: '4px',
+    padding: '2px 4px',
+    fontSize: '0.82em',
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Open Sans", "Helvetica Neue", sans-serif',
+  },
+  decrease: {
+    color: '#216e4e',
+    backgroundColor: '#dcfff1',
+    borderRadius: '4px',
+    padding: '2px 4px',
+    fontSize: '0.82em',
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Open Sans", "Helvetica Neue", sans-serif',
+  },
+  noChange: {
+    color: '#0052cc',
+    backgroundColor: '#e9f2ff',
+    borderRadius: '4px',
+    padding: '2px 4px',
+    fontSize: '0.82em',
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Open Sans", "Helvetica Neue", sans-serif',
+  },
+  regular: {
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Open Sans", "Helvetica Neue", sans-serif',
+  },
+  bold: {
+    fontWeight: 'bold',
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Open Sans", "Helvetica Neue", sans-serif',
+  },
+});
+
+const COLORS = [
+  '#8884d8',
+  '#82ca9d',
+  '#ffc658',
+  '#ff7300',
+  '#413ea0',
+  '#ff0000',
+  '#00ff00',
+  '#0000ff',
+  '#ff00ff',
+  '#00ffff',
+
+];
 
 export const EntityInfraWalletCard = () => {
+  const classes = useStyles();
   const { entity } = useEntity();
   const infrawalletApi = useApi(infraWalletApiRef);
-  const catalogApi = useApi(catalogApiRef);
 
-  const [gcpProjectIds, setGcpProjectIds] = useState<string[]>([]);
   const [costData, setCostData] = useState<Report[] | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  const [debugInfo, setDebugInfo] = useState<string>('');
-
-  useEffect(() => {
-    const fetchGcpProjectIds = async () => {
-      try {
-        let projectIds: string[] = [];
-
-        const annotationGcpProjectIds = entity.metadata.annotations?.['infrawallet.io/gcp-project-ids'];
-        if (annotationGcpProjectIds) {
-          projectIds = annotationGcpProjectIds.split(',').map(id => id.trim());
-        }
-
-        const dependsOnRelations = entity.relations?.filter(rel => rel.type === 'dependsOn') || [];
-        const targetEntityRefs = dependsOnRelations.map(rel => rel.targetRef);
-
-        const targetEntitiesPromises = targetEntityRefs.map(ref => catalogApi.getEntityByRef(ref));
-        const targetEntities = await Promise.all(targetEntitiesPromises);
-
-        for (const targetEntity of targetEntities) {
-          if (
-            targetEntity?.kind.toLocaleLowerCase('en-US') === 'resource' &&
-            targetEntity.spec?.type === 'gcp-project'
-          ) {
-            const gcpProjectId = targetEntity.metadata.name;
-            projectIds.push(gcpProjectId);
-          }
-        }
-
-        setGcpProjectIds(projectIds);
-        setDebugInfo(prev => prev + `Resolved GCP Project IDs: ${projectIds.join(', ')}\n`);
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Unknown error occurred');
-      }
-    };
-
-    fetchGcpProjectIds();
-  }, [entity, catalogApi]);
+  const [tabIndex, setTabIndex] = useState<number>(0);
 
   useEffect(() => {
     const fetchCostData = async () => {
       setLoading(true);
       setError(null);
       try {
-        if (gcpProjectIds.length === 0) {
-          setCostData(null);
-          setLoading(false);
-          return;
+        const annotations = entity.metadata.annotations || {};
+
+
+        const annotationKeys = [
+          'infrawallet.io/project',
+          'infrawallet.io/account',
+          'infrawallet.io/service',
+          'infrawallet.io/category',
+          'infrawallet.io/provider',
+        ];
+
+        const filtersObj: Record<string, string[]> = {};
+
+        annotationKeys.forEach((key) => {
+          if (annotations[key]) {
+            const shortKey = key.replace('infrawallet.io/', '');
+            const values = annotations[key]
+              .split(',')
+              .map((v: string) => v.trim())
+              .filter((v: string) => v.length > 0);
+            filtersObj[shortKey] = values;
+          }
+        });
+
+
+        if (annotations['infrawallet.io/extra-filters']) {
+          const extraFilters = annotations['infrawallet.io/extra-filters'];
+          // assuming extra-filters are in the format "key1: value1, key2: value2"
+          extraFilters.split(',').forEach((pair) => {
+            const [key, value] = pair.split(':').map((s) => s.trim());
+            if (key && value) {
+              const values = value
+                .split('|')
+                .map((v: string) => v.trim())
+                .filter((v: string) => v.length > 0);
+              filtersObj[key] = values;
+            }
+          });
         }
 
-        const filters = `(${gcpProjectIds.map(id => `gcp_project_id=${id}`).join(' OR ')})`;
+        // build filters string for API call (include all filters)
+        const filtersArray = Object.entries(filtersObj).map(([key, values]) => {
+          if (values.length === 1) {
+            return `${key}:${values[0]}`;
+          } else {
+            const valuesString = values.join('|');
+            return `${key}:(${valuesString})`;
+          }
+        });
+        const filters = `(${filtersArray.join(',')})`;
+
         const tags: Tag[] = [];
         const groups = '';
         const granularity = 'monthly';
+
         const endTime = new Date();
         const startTime = new Date();
-        startTime.setMonth(endTime.getMonth() - 1);
+        startTime.setMonth(endTime.getMonth() - 2);
 
-        setDebugInfo(prev => prev + `Filters: ${filters}\n`);
 
         const costReportsResponse = await infrawalletApi.getCostReports(
           filters,
@@ -81,7 +162,7 @@ export const EntityInfraWalletCard = () => {
           groups,
           granularity,
           startTime,
-          endTime,
+          endTime
         );
 
         if (costReportsResponse.status !== 200) {
@@ -97,7 +178,7 @@ export const EntityInfraWalletCard = () => {
     };
 
     fetchCostData();
-  }, [gcpProjectIds, infrawalletApi]);
+  }, [entity, infrawalletApi]);
 
   if (loading) {
     return <Progress />;
@@ -111,25 +192,221 @@ export const EntityInfraWalletCard = () => {
     return <Alert severity="info">No cost data available for this entity.</Alert>;
   }
 
+  // prep periods
+  const periods = new Set<string>();
+  costData.forEach((report) => {
+    Object.keys(report.reports).forEach((period) => periods.add(period));
+  });
+
+  // convert periods to array and sort
+  const sortedPeriods = Array.from(periods).sort();
+
+  // calculate total cost for each period
+  const totalCostsByPeriod = sortedPeriods.map((period) => {
+    const total = costData.reduce((sum, report) => {
+      return sum + (report.reports[period] || 0);
+    }, 0);
+    return { period, total };
+  });
+
+  // calculate total cost for current and previous months
+  const currentPeriod = sortedPeriods[sortedPeriods.length - 1];
+  const previousPeriod = sortedPeriods.length > 1 ? sortedPeriods[sortedPeriods.length - 2] : null;
+
+  const totalCost = totalCostsByPeriod.find((item) => item.period === currentPeriod)?.total || 0;
+  const previousTotalCost =
+    previousPeriod ? totalCostsByPeriod.find((item) => item.period === previousPeriod)?.total || 0 : 0;
+
+  // calculate percentage change
+  const percentageChange =
+    previousTotalCost !== 0 ? ((totalCost - previousTotalCost) / previousTotalCost) * 100 : 0;
+  const isIncrease = percentageChange > 0;
+  const percentageChangeFormatted = Math.abs(percentageChange).toFixed(2);
+  let mark = '';
+  if (percentageChange < 0) {
+    mark = '▼';
+  } else if (percentageChange > 0) {
+    mark = '▲';
+  }
+
+
+
+  // 1. extract unique project IDs
+  const projects = Array.from(
+    new Set(
+      costData
+        .map((report) => {
+          const project = report.project as string | undefined;
+          return typeof project === 'string' ? project : undefined;
+        })
+        .filter((project): project is string => !!project)
+    )
+  );
+
+
+  if (projects.length === 0) {
+    return <Alert severity="warning">No project data available to display in the chart.</Alert>;
+  }
+
+  // 2. build chart data with per-project costs
+  const chartData = sortedPeriods.map((period) => {
+    const dataPoint: Record<string, any> = { period };
+    projects.forEach((project) => {
+
+      const projectReports = costData.filter((report) => report.project === project);
+      const total = projectReports.reduce((sum, report) => {
+        return sum + (report.reports[period] || 0);
+      }, 0);
+      dataPoint[project] = total;
+    });
+    return dataPoint;
+  });
+
+  // 3. calculate per-service costs for current period
+  const perServiceCosts = costData.reduce((acc, report) => {
+    const service = report.service as string | undefined;
+    const cost = report.reports[currentPeriod] || 0;
+    if (typeof service === 'string') {
+      if (!acc[service]) {
+        acc[service] = 0;
+      }
+      acc[service] += cost;
+    }
+    return acc;
+  }, {} as Record<string, number>);
+
+  // 4. calculate per-service costs for previous period
+  const prevPerServiceCosts = previousPeriod
+    ? costData.reduce((acc, report) => {
+        const service = report.service as string | undefined;
+        const cost = report.reports[previousPeriod] || 0;
+        if (typeof service === 'string') {
+          if (!acc[service]) {
+            acc[service] = 0;
+          }
+          acc[service] += cost;
+        }
+        return acc;
+      }, {} as Record<string, number>)
+    : {};
+
+  // 5. prepare data for per-service table
+  const serviceRows = Object.entries(perServiceCosts).map(([service, cost]) => {
+    const prevCost = prevPerServiceCosts[service] || 0;
+    const change = prevCost !== 0 ? ((cost - prevCost) / prevCost) * 100 : 0;
+    return {
+      service,
+      cost,
+      change,
+    };
+  });
+
+  const handleTabChange = (_event: React.ChangeEvent<{}>, newValue: number) => {
+    setTabIndex(newValue);
+  };
+
   return (
-    <InfoCard title="Cost Information">
-      <Typography variant="body2">
-        <pre>{debugInfo}</pre>
-      </Typography>
-      {costData.map((report: Report) => (
-        <Card variant="outlined" key={report.id} style={{ marginBottom: '16px' }}>
-          <CardContent>
-            <Typography variant="h6">Project ID: {report.id}</Typography>
-            <Typography variant="body2">
-              {Object.entries(report.reports).map(([period, cost]) => (
-                <div key={period}>
-                  {period}: ${Number(cost).toFixed(2)}
-                </div>
-              ))}
+    <InfoCard title="InfraWallet">
+      <Tabs value={tabIndex} onChange={handleTabChange} aria-label="Cost Tabs">
+        <Tab label="Total Cost" />
+        <Tab label="Service Breakdown" />
+      </Tabs>
+
+      {/* total cost tab */}
+      {tabIndex === 0 && (
+        <Box p={2}>
+          <Box display="flex" alignItems="center">
+            {previousTotalCost > 0 && (
+              <Box
+                className={
+                  isIncrease
+                    ? classes.increase
+                    : percentageChange === 0
+                    ? classes.noChange
+                    : classes.decrease
+                }
+                mr={1}
+              >
+                {mark} {percentageChangeFormatted}%
+              </Box>
+            )}
+            <Typography variant="h6" className={classes.bold}>
+              Current Month: ${totalCost.toFixed(2)}
             </Typography>
-          </CardContent>
-        </Card>
-      ))}
+          </Box>
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="period" />
+              <YAxis />
+              <Tooltip />
+              <Legend />
+              {projects.map((project, index) => (
+                <Line
+                  key={project}
+                  type="monotone"
+                  dataKey={project}
+                  stroke={COLORS[index % COLORS.length]}
+                  activeDot={{ r: 8 }}
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        </Box>
+      )}
+
+      {/* per-service cost tab */}
+      {tabIndex === 1 && (
+        <Box p={2}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell className={classes.bold}>Service</TableCell>
+                <TableCell align="right" className={classes.bold}>
+                  Monthly Cost
+                </TableCell>
+                <TableCell align="right" className={classes.bold}>
+                  Monthly Change
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {serviceRows.map((row) => {
+                const isIncrease = row.change > 0;
+                const changeFormatted = Math.abs(row.change).toFixed(2);
+                let mark = '';
+                if (row.change < 0) {
+                  mark = '▼';
+                } else if (row.change > 0) {
+                  mark = '▲';
+                }
+                return (
+                  <TableRow key={row.service}>
+                    <TableCell component="th" scope="row">
+                      {row.service}
+                    </TableCell>
+                    <TableCell align="right">${row.cost.toFixed(2)}</TableCell>
+                    <TableCell align="right">
+                      <Box
+                        className={
+                          isIncrease
+                            ? classes.increase
+                            : row.change === 0
+                            ? classes.noChange
+                            : classes.decrease
+                        }
+                        display="inline"
+                      >
+                        {mark} {changeFormatted}%
+                      </Box>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </Box>
+      )}
     </InfoCard>
   );
 };

--- a/plugins/infrawallet/src/components/EntityInfraWalletCard/EntityInfraWalletCard.tsx
+++ b/plugins/infrawallet/src/components/EntityInfraWalletCard/EntityInfraWalletCard.tsx
@@ -5,28 +5,9 @@ import { useApi } from '@backstage/core-plugin-api';
 import { infraWalletApiRef } from '../../api/InfraWalletApi';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { Report, Tag } from '../../api/types';
-import {
-  Typography,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
-  Tabs,
-  Tab,
-  Box,
-} from '@material-ui/core';
+import { Typography, Table, TableBody, TableCell, TableHead, TableRow, Tabs, Tab, Box } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import {
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  CartesianGrid,
-  Legend,
-} from 'recharts';
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Legend } from 'recharts';
 
 const useStyles = makeStyles({
   increase: {
@@ -107,7 +88,7 @@ export const EntityInfraWalletCard = () => {
 
         const filtersObj: Record<string, string[]> = {};
 
-        annotationKeys.forEach((key) => {
+        annotationKeys.forEach(key => {
           if (annotations[key]) {
             const shortKey = key.replace('infrawallet.io/', '');
             const values = annotations[key]
@@ -121,8 +102,8 @@ export const EntityInfraWalletCard = () => {
         if (annotations['infrawallet.io/extra-filters']) {
           const extraFilters = annotations['infrawallet.io/extra-filters'];
           // assuming extra-filters are in the format "key1: value1, key2: value2"
-          extraFilters.split(',').forEach((pair) => {
-            const [key, value] = pair.split(':').map((s) => s.trim());
+          extraFilters.split(',').forEach(pair => {
+            const [key, value] = pair.split(':').map(s => s.trim());
             if (key && value) {
               const values = value
                 .split('|')
@@ -157,7 +138,7 @@ export const EntityInfraWalletCard = () => {
           groups,
           granularity,
           startTime,
-          endTime
+          endTime,
         );
 
         if (costReportsResponse.status !== 200) {
@@ -189,14 +170,14 @@ export const EntityInfraWalletCard = () => {
 
   // prepare periods
   const periods = new Set<string>();
-  costData.forEach((report) => {
-    Object.keys(report.reports).forEach((period) => periods.add(period));
+  costData.forEach(report => {
+    Object.keys(report.reports).forEach(period => periods.add(period));
   });
 
   const sortedPeriods = Array.from(periods).sort();
 
   // calculate total cost for each period
-  const totalCostsByPeriod = sortedPeriods.map((period) => {
+  const totalCostsByPeriod = sortedPeriods.map(period => {
     const total = costData.reduce((sum, report) => {
       return sum + (report.reports[period] || 0);
     }, 0);
@@ -207,13 +188,13 @@ export const EntityInfraWalletCard = () => {
   const currentPeriod = sortedPeriods[sortedPeriods.length - 1];
   const previousPeriod = sortedPeriods.length > 1 ? sortedPeriods[sortedPeriods.length - 2] : null;
 
-  const totalCost = totalCostsByPeriod.find((item) => item.period === currentPeriod)?.total || 0;
-  const previousTotalCost =
-    previousPeriod ? totalCostsByPeriod.find((item) => item.period === previousPeriod)?.total || 0 : 0;
+  const totalCost = totalCostsByPeriod.find(item => item.period === currentPeriod)?.total || 0;
+  const previousTotalCost = previousPeriod
+    ? totalCostsByPeriod.find(item => item.period === previousPeriod)?.total || 0
+    : 0;
 
   // calculate percentage change
-  const percentageChange =
-    previousTotalCost !== 0 ? ((totalCost - previousTotalCost) / previousTotalCost) * 100 : 0;
+  const percentageChange = previousTotalCost !== 0 ? ((totalCost - previousTotalCost) / previousTotalCost) * 100 : 0;
   const percentageChangeFormatted = Math.abs(percentageChange).toFixed(2);
   let mark = '';
   if (percentageChange < 0) {
@@ -226,12 +207,12 @@ export const EntityInfraWalletCard = () => {
   const projects = Array.from(
     new Set(
       costData
-        .map((report) => {
+        .map(report => {
           const project = report.project as string | undefined;
           return typeof project === 'string' ? project : undefined;
         })
-        .filter((project): project is string => !!project)
-    )
+        .filter((project): project is string => !!project),
+    ),
   );
 
   if (projects.length === 0) {
@@ -239,10 +220,10 @@ export const EntityInfraWalletCard = () => {
   }
 
   // 2. build chart data with per-project costs
-  const chartData = sortedPeriods.map((period) => {
+  const chartData = sortedPeriods.map(period => {
     const dataPoint: Record<string, any> = { period };
-    projects.forEach((project) => {
-      const projectReports = costData.filter((report) => report.project === project);
+    projects.forEach(project => {
+      const projectReports = costData.filter(report => report.project === project);
       const total = projectReports.reduce((sum, report) => {
         return sum + (report.reports[period] || 0);
       }, 0);
@@ -328,10 +309,7 @@ export const EntityInfraWalletCard = () => {
         <Box p={2}>
           <Box display="flex" alignItems="center">
             {previousTotalCost > 0 && (
-              <Box
-                className={getChangeClass(percentageChange)}
-                mr={1}
-              >
+              <Box className={getChangeClass(percentageChange)} mr={1}>
                 {mark} {percentageChangeFormatted}%
               </Box>
             )}
@@ -376,7 +354,7 @@ export const EntityInfraWalletCard = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {serviceRows.map((row) => {
+              {serviceRows.map(row => {
                 const serviceChangeClass = getChangeClass(row.change);
                 const serviceMark = getChangeMark(row.change);
                 const changeFormatted = Math.abs(row.change).toFixed(2);
@@ -387,10 +365,7 @@ export const EntityInfraWalletCard = () => {
                     </TableCell>
                     <TableCell align="right">${row.cost.toFixed(2)}</TableCell>
                     <TableCell align="right">
-                      <Box
-                        className={serviceChangeClass}
-                        display="inline"
-                      >
+                      <Box className={serviceChangeClass} display="inline">
                         {serviceMark} {changeFormatted}%
                       </Box>
                     </TableCell>

--- a/plugins/infrawallet/src/components/EntityInfraWalletCard/index.ts
+++ b/plugins/infrawallet/src/components/EntityInfraWalletCard/index.ts
@@ -1,0 +1,1 @@
+export { EntityInfraWalletCard } from './EntityInfraWalletCard';

--- a/plugins/infrawallet/src/components/InfraWalletAppData.tsx
+++ b/plugins/infrawallet/src/components/InfraWalletAppData.tsx
@@ -1,0 +1,52 @@
+import { Entity } from '@backstage/catalog-model';
+
+export const INFRAWALLET_ANNOTATION_PROJECT = 'infrawallet.io/project';
+export const INFRAWALLET_ANNOTATION_ACCOUNT = 'infrawallet.io/account';
+export const INFRAWALLET_ANNOTATION_SERVICE = 'infrawallet.io/service';
+export const INFRAWALLET_ANNOTATION_CATEGORY = 'infrawallet.io/category';
+export const INFRAWALLET_ANNOTATION_PROVIDER = 'infrawallet.io/provider';
+export const INFRAWALLET_ANNOTATION_EXTRAS = 'infrawallet.io/extra-filters';
+
+
+
+
+export const getInfraWalletProjectAnnotation = (entity: Entity) => {
+  const project =
+    entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_PROJECT] ?? '';
+
+  return project;
+};
+
+export const getInfraWalletAccountAnnotation = (entity: Entity) => {
+  const account =
+    entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_ACCOUNT] ?? '';
+
+  return account;
+};
+
+export const getInfraWalletServiceAnnotation = (entity: Entity) => {
+  const service =
+    entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_SERVICE] ?? '';
+
+  return service;
+};
+
+export const getInfraWalletCategoryAnnotation = (entity: Entity) => {
+    const category =
+      entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_CATEGORY] ?? '';
+
+    return category;
+  };
+  export const getInfraWalletProviderAnnotation = (entity: Entity) => {
+    const provider =
+      entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_PROVIDER] ?? '';
+
+    return provider;
+  };
+
+  export const getInfraWalletExtrasAnnotation = (entity: Entity) => {
+    const extras =
+      entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_EXTRAS] ?? '';
+
+    return extras;
+  };

--- a/plugins/infrawallet/src/components/InfraWalletAppData.tsx
+++ b/plugins/infrawallet/src/components/InfraWalletAppData.tsx
@@ -7,46 +7,37 @@ export const INFRAWALLET_ANNOTATION_CATEGORY = 'infrawallet.io/category';
 export const INFRAWALLET_ANNOTATION_PROVIDER = 'infrawallet.io/provider';
 export const INFRAWALLET_ANNOTATION_EXTRAS = 'infrawallet.io/extra-filters';
 
-
-
-
 export const getInfraWalletProjectAnnotation = (entity: Entity) => {
-  const project =
-    entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_PROJECT] ?? '';
+  const project = entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_PROJECT] ?? '';
 
   return project;
 };
 
 export const getInfraWalletAccountAnnotation = (entity: Entity) => {
-  const account =
-    entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_ACCOUNT] ?? '';
+  const account = entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_ACCOUNT] ?? '';
 
   return account;
 };
 
 export const getInfraWalletServiceAnnotation = (entity: Entity) => {
-  const service =
-    entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_SERVICE] ?? '';
+  const service = entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_SERVICE] ?? '';
 
   return service;
 };
 
 export const getInfraWalletCategoryAnnotation = (entity: Entity) => {
-    const category =
-      entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_CATEGORY] ?? '';
+  const category = entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_CATEGORY] ?? '';
 
-    return category;
-  };
-  export const getInfraWalletProviderAnnotation = (entity: Entity) => {
-    const provider =
-      entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_PROVIDER] ?? '';
+  return category;
+};
+export const getInfraWalletProviderAnnotation = (entity: Entity) => {
+  const provider = entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_PROVIDER] ?? '';
 
-    return provider;
-  };
+  return provider;
+};
 
-  export const getInfraWalletExtrasAnnotation = (entity: Entity) => {
-    const extras =
-      entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_EXTRAS] ?? '';
+export const getInfraWalletExtrasAnnotation = (entity: Entity) => {
+  const extras = entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_EXTRAS] ?? '';
 
-    return extras;
-  };
+  return extras;
+};

--- a/plugins/infrawallet/src/components/index.ts
+++ b/plugins/infrawallet/src/components/index.ts
@@ -1,3 +1,43 @@
 export { InfraWalletIcon } from './InfraWalletIcon';
 export { EntityInfraWalletCard } from './EntityInfraWalletCard';
 export type { ReportsComponentProps } from './ReportsComponent';
+import { Entity } from '@backstage/catalog-model';
+import {
+  INFRAWALLET_ANNOTATION_PROJECT,
+  INFRAWALLET_ANNOTATION_ACCOUNT,
+  INFRAWALLET_ANNOTATION_SERVICE,
+  INFRAWALLET_ANNOTATION_CATEGORY,
+  INFRAWALLET_ANNOTATION_PROVIDER,
+  INFRAWALLET_ANNOTATION_EXTRAS,
+} from './InfraWalletAppData'
+
+export const isInfraWalletProjectIDAnnotationAvailable = (entity: Entity) =>
+  Boolean(entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_PROJECT]);
+
+export const isInfraWalletAccountAnnotationAvailable = (entity: Entity) =>
+  Boolean(entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_ACCOUNT]);
+
+export const isInfraWalletServiceAnnotationAvailable = (entity: Entity) =>
+  Boolean(entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_SERVICE]);
+
+export const isInfraWalletCategoryAnnotationAvailable = (entity: Entity) =>
+  Boolean(entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_CATEGORY]);
+
+export const isInfraWalletProviderAnnotationAvailable = (entity: Entity) =>
+  Boolean(entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_PROVIDER]);
+
+export const isInfraWalletExtrasAnnotationAvailable = (entity: Entity) =>
+  Boolean(entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_EXTRAS]);
+
+export const isInfraWalletAvailable = (entity: Entity) => {
+    console.log('isInfraWalletAvailable called with entity:', entity.metadata.name);
+    const available =
+      isInfraWalletProjectIDAnnotationAvailable(entity) ||
+      isInfraWalletAccountAnnotationAvailable(entity) ||
+      isInfraWalletServiceAnnotationAvailable(entity) ||
+      isInfraWalletCategoryAnnotationAvailable(entity) ||
+      isInfraWalletProviderAnnotationAvailable(entity) ||
+      isInfraWalletExtrasAnnotationAvailable(entity);
+    console.log('isInfraWalletAvailable returns:', available);
+    return available;
+  };

--- a/plugins/infrawallet/src/components/index.ts
+++ b/plugins/infrawallet/src/components/index.ts
@@ -9,7 +9,7 @@ import {
   INFRAWALLET_ANNOTATION_CATEGORY,
   INFRAWALLET_ANNOTATION_PROVIDER,
   INFRAWALLET_ANNOTATION_EXTRAS,
-} from './InfraWalletAppData'
+} from './InfraWalletAppData';
 
 export const isInfraWalletProjectIDAnnotationAvailable = (entity: Entity) =>
   Boolean(entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_PROJECT]);
@@ -30,12 +30,12 @@ export const isInfraWalletExtrasAnnotationAvailable = (entity: Entity) =>
   Boolean(entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_EXTRAS]);
 
 export const isInfraWalletAvailable = (entity: Entity) => {
-    const available =
-      isInfraWalletProjectIDAnnotationAvailable(entity) ||
-      isInfraWalletAccountAnnotationAvailable(entity) ||
-      isInfraWalletServiceAnnotationAvailable(entity) ||
-      isInfraWalletCategoryAnnotationAvailable(entity) ||
-      isInfraWalletProviderAnnotationAvailable(entity) ||
-      isInfraWalletExtrasAnnotationAvailable(entity);
-    return available;
-  };
+  const available =
+    isInfraWalletProjectIDAnnotationAvailable(entity) ||
+    isInfraWalletAccountAnnotationAvailable(entity) ||
+    isInfraWalletServiceAnnotationAvailable(entity) ||
+    isInfraWalletCategoryAnnotationAvailable(entity) ||
+    isInfraWalletProviderAnnotationAvailable(entity) ||
+    isInfraWalletExtrasAnnotationAvailable(entity);
+  return available;
+};

--- a/plugins/infrawallet/src/components/index.ts
+++ b/plugins/infrawallet/src/components/index.ts
@@ -30,7 +30,6 @@ export const isInfraWalletExtrasAnnotationAvailable = (entity: Entity) =>
   Boolean(entity.metadata.annotations?.[INFRAWALLET_ANNOTATION_EXTRAS]);
 
 export const isInfraWalletAvailable = (entity: Entity) => {
-    console.log('isInfraWalletAvailable called with entity:', entity.metadata.name);
     const available =
       isInfraWalletProjectIDAnnotationAvailable(entity) ||
       isInfraWalletAccountAnnotationAvailable(entity) ||
@@ -38,6 +37,5 @@ export const isInfraWalletAvailable = (entity: Entity) => {
       isInfraWalletCategoryAnnotationAvailable(entity) ||
       isInfraWalletProviderAnnotationAvailable(entity) ||
       isInfraWalletExtrasAnnotationAvailable(entity);
-    console.log('isInfraWalletAvailable returns:', available);
     return available;
   };

--- a/plugins/infrawallet/src/components/index.ts
+++ b/plugins/infrawallet/src/components/index.ts
@@ -1,2 +1,3 @@
 export { InfraWalletIcon } from './InfraWalletIcon';
+export { EntityInfraWalletCard } from './EntityInfraWalletCard';
 export type { ReportsComponentProps } from './ReportsComponent';

--- a/plugins/infrawallet/src/index.ts
+++ b/plugins/infrawallet/src/index.ts
@@ -1,3 +1,4 @@
+export { isInfraWalletAvailable } from './components';
 export type { ReportsComponentProps } from './components';
 export { InfraWalletIcon } from './components';
 export { infraWalletPlugin, InfraWalletPage, EntityInfraWalletCard } from './plugin';

--- a/plugins/infrawallet/src/index.ts
+++ b/plugins/infrawallet/src/index.ts
@@ -1,3 +1,3 @@
 export type { ReportsComponentProps } from './components';
 export { InfraWalletIcon } from './components';
-export { infraWalletPlugin, InfraWalletPage } from './plugin';
+export { infraWalletPlugin, InfraWalletPage, EntityInfraWalletCard } from './plugin';

--- a/plugins/infrawallet/src/plugin.ts
+++ b/plugins/infrawallet/src/plugin.ts
@@ -2,6 +2,7 @@ import {
   createApiFactory,
   createPlugin,
   createRoutableExtension,
+  createComponentExtension,
   identityApiRef,
   configApiRef,
 } from '@backstage/core-plugin-api';
@@ -30,5 +31,14 @@ export const InfraWalletPage = infraWalletPlugin.provide(
     name: 'InfraWalletPage',
     component: () => import('./components/Router').then(m => m.Router),
     mountPoint: rootRouteRef,
+  }),
+);
+
+export const EntityInfraWalletCard = infraWalletPlugin.provide(
+  createComponentExtension({
+    name: 'EntityInfraWalletCard',
+    component: {
+      lazy: () => import('./components/EntityInfraWalletCard').then(m => m.EntityInfraWalletCard),
+    },
   }),
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3255,27 +3255,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-client@npm:^1.6.5":
-  version: 1.6.5
-  resolution: "@backstage/catalog-client@npm:1.6.5"
+"@backstage/catalog-client@npm:^1.6.5, @backstage/catalog-client@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "@backstage/catalog-client@npm:1.7.0"
   dependencies:
-    "@backstage/catalog-model": ^1.5.0
+    "@backstage/catalog-model": ^1.7.0
     "@backstage/errors": ^1.2.4
     cross-fetch: ^4.0.0
     uri-template: ^2.0.0
-  checksum: afb84382c7a8e9124090d56ec4a3a1e8ab7dfda33d337851412b9ee4fca0e85fb7263729d6eb4efa8c3198343ed03843ef468492f74401951542908534febfad
+  checksum: 66a0570c57281fbf7b59786ebf2dd97efbb5c7c7393025e14a605d38f1bf2317974c319da138146e21d31ac83c3214223631211ebbee36fc96c84bd803acd913
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "@backstage/catalog-model@npm:1.5.0"
+"@backstage/catalog-model@npm:^1.5.0, @backstage/catalog-model@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "@backstage/catalog-model@npm:1.7.0"
   dependencies:
     "@backstage/errors": ^1.2.4
     "@backstage/types": ^1.1.1
     ajv: ^8.10.0
     lodash: ^4.17.21
-  checksum: 545873625afbb25a2142af9f8c701547b448fe8b822c9ed699c86a9c385571014115a2c3105a3dca2bc2ac63b837b093dba39a973c2f9e23521d427a0328ba12
+  checksum: 6ff537e9e6064d35fa4a173a1c96f94e904489494a67a136e2dd0a743f9e3f4fd8a1f7a661fe8495dfbb642aabcc8fbf1746a300ad496b6e4a5d02f4db00f914
   languageName: node
   linkType: hard
 
@@ -3496,6 +3496,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/core-compat-api@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@backstage/core-compat-api@npm:0.3.0"
+  dependencies:
+    "@backstage/core-plugin-api": ^1.9.4
+    "@backstage/frontend-plugin-api": ^0.8.0
+    "@backstage/version-bridge": ^1.0.9
+    "@types/react": ^16.13.1 || ^17.0.0
+    lodash: ^4.17.21
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  checksum: ff9f662a007c07dc1353e376ef2c40abac84123c1442f8d4307e0f98c050d8f9b4fab4f043538014d740c2d18ef7c682df12cc4f26d0c58aca0f42413e86a001
+  languageName: node
+  linkType: hard
+
 "@backstage/core-components@npm:^0.14.7":
   version: 0.14.7
   resolution: "@backstage/core-components@npm:0.14.7"
@@ -3545,21 +3561,70 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@npm:^1.9.2":
-  version: 1.9.2
-  resolution: "@backstage/core-plugin-api@npm:1.9.2"
+"@backstage/core-components@npm:^0.15.0":
+  version: 0.15.0
+  resolution: "@backstage/core-components@npm:0.15.0"
+  dependencies:
+    "@backstage/config": ^1.2.0
+    "@backstage/core-plugin-api": ^1.9.4
+    "@backstage/errors": ^1.2.4
+    "@backstage/theme": ^0.5.7
+    "@backstage/version-bridge": ^1.0.9
+    "@date-io/core": ^1.3.13
+    "@material-table/core": ^3.1.0
+    "@material-ui/core": ^4.12.2
+    "@material-ui/icons": ^4.9.1
+    "@material-ui/lab": 4.0.0-alpha.61
+    "@react-hookz/web": ^24.0.0
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    "@types/react-sparklines": ^1.7.0
+    ansi-regex: ^6.0.1
+    classnames: ^2.2.6
+    d3-selection: ^3.0.0
+    d3-shape: ^3.0.0
+    d3-zoom: ^3.0.0
+    dagre: ^0.8.5
+    linkify-react: 4.1.3
+    linkifyjs: 4.1.3
+    lodash: ^4.17.21
+    pluralize: ^8.0.0
+    qs: ^6.9.4
+    rc-progress: 3.5.1
+    react-helmet: 6.1.0
+    react-hook-form: ^7.12.2
+    react-idle-timer: 5.7.2
+    react-markdown: ^8.0.0
+    react-sparklines: ^1.7.0
+    react-syntax-highlighter: ^15.4.5
+    react-use: ^17.3.2
+    react-virtualized-auto-sizer: ^1.0.11
+    react-window: ^1.8.6
+    remark-gfm: ^3.0.1
+    zen-observable: ^0.10.0
+    zod: ^3.22.4
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  checksum: 98887230c4475ab29795aced0ac156be828517553a61a6fc59ec058928cfc3c63e9410523f4c49cbf893268469a9c28b1bdce3311b888f06263e069987255d25
+  languageName: node
+  linkType: hard
+
+"@backstage/core-plugin-api@npm:^1.9.2, @backstage/core-plugin-api@npm:^1.9.4":
+  version: 1.9.4
+  resolution: "@backstage/core-plugin-api@npm:1.9.4"
   dependencies:
     "@backstage/config": ^1.2.0
     "@backstage/errors": ^1.2.4
     "@backstage/types": ^1.1.1
-    "@backstage/version-bridge": ^1.0.8
+    "@backstage/version-bridge": ^1.0.9
     "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
     history: ^5.0.0
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 2df505c14853b3b35b8644d66f3e58d235bc6ee7f7b81785ec163aa9f089fc03a6c03e3b191d001b247f19d97063e02e585d67661720a8b6a13ab67a2403c218
+  checksum: 921b1185a2b68363f2cfe66f5cfa003c2f56abb252f75b0d37d49eb586d5e1347d34e846eb72bab71df5f478f106de1fe7e0e05876e559e2c28b23d849994910
   languageName: node
   linkType: hard
 
@@ -3622,14 +3687,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@npm:^0.6.5":
-  version: 0.6.5
-  resolution: "@backstage/frontend-plugin-api@npm:0.6.5"
+"@backstage/frontend-plugin-api@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@backstage/frontend-plugin-api@npm:0.8.0"
   dependencies:
-    "@backstage/core-components": ^0.14.7
-    "@backstage/core-plugin-api": ^1.9.2
+    "@backstage/core-components": ^0.15.0
+    "@backstage/core-plugin-api": ^1.9.4
     "@backstage/types": ^1.1.1
-    "@backstage/version-bridge": ^1.0.8
+    "@backstage/version-bridge": ^1.0.9
     "@material-ui/core": ^4.12.4
     "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
     lodash: ^4.17.21
@@ -3638,7 +3703,7 @@ __metadata:
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: be880b5a3bb86d4e2c32a90ca64265b529901dabcdcbf5a87b5cbdfd68fc347297359550da195034e671e074db9db7c659d663d4fd46ed3836896bd1878fae2f
+  checksum: 2880ba13514c4620cad030e9a98d98076636e89e9cbb2aec2c44605d1b14774a9388eb43bde52f51c32070d5137134fcb5a059c1080194154dad9673ef11cf5f
   languageName: node
   linkType: hard
 
@@ -3657,13 +3722,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@npm:^1.1.27":
-  version: 1.1.27
-  resolution: "@backstage/integration-react@npm:1.1.27"
+"@backstage/integration-react@npm:^1.1.27, @backstage/integration-react@npm:^1.1.31":
+  version: 1.1.31
+  resolution: "@backstage/integration-react@npm:1.1.31"
   dependencies:
     "@backstage/config": ^1.2.0
-    "@backstage/core-plugin-api": ^1.9.2
-    "@backstage/integration": ^1.11.0
+    "@backstage/core-plugin-api": ^1.9.4
+    "@backstage/integration": ^1.15.0
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@types/react": ^16.13.1 || ^17.0.0
@@ -3671,13 +3736,13 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 136bdfeb7c4ba91eb2405a82ae99fd5d935056d7fe77064bf799a8d375a2b5c645e0df7deaee7e1e0ad6fb48dcac94c82e4b29e3d3a00f80555116b1902102b2
+  checksum: a31313bc3cd2189535eee6150ad49963f3172fa33d1c1f1c7f93e46b891c67ead9e0ea810bcfcbd6dc5ceabebb2036b0d562ec2088b0559d48c22e8b65e09bd1
   languageName: node
   linkType: hard
 
-"@backstage/integration@npm:^1.11.0":
-  version: 1.11.0
-  resolution: "@backstage/integration@npm:1.11.0"
+"@backstage/integration@npm:^1.11.0, @backstage/integration@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "@backstage/integration@npm:1.15.0"
   dependencies:
     "@azure/identity": ^4.0.0
     "@backstage/config": ^1.2.0
@@ -3688,7 +3753,7 @@ __metadata:
     git-url-parse: ^14.0.0
     lodash: ^4.17.21
     luxon: ^3.0.0
-  checksum: 57ea46e57da004cdab41e82f558105f78f84f65d58163e93363dc775d42ab29401d3a38390ace012bf388eec57350d432a415d8fed27e57419e21522044fcc33
+  checksum: a2c5b51b1403341f56fe91bd53a1105875855642927b95277c3e8ea29d604b718c39984fd2b8cd298d6206d1f23718da10dbbb53f4ec6eb74b296e6621fc4b7e
   languageName: node
   linkType: hard
 
@@ -4023,14 +4088,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@npm:^1.0.23":
-  version: 1.0.23
-  resolution: "@backstage/plugin-catalog-common@npm:1.0.23"
+"@backstage/plugin-catalog-common@npm:^1.0.23, @backstage/plugin-catalog-common@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@backstage/plugin-catalog-common@npm:1.1.0"
   dependencies:
-    "@backstage/catalog-model": ^1.5.0
-    "@backstage/plugin-permission-common": ^0.7.13
-    "@backstage/plugin-search-common": ^1.2.11
-  checksum: 071456b301689b9b349bdb1bea0d81cc41b0e8055e68096655a0abd198ea21afdc27bda7135d5c800ba8074fbc20d2d8d3a2244578fa8f6547205bee57c31c3d
+    "@backstage/catalog-model": ^1.7.0
+    "@backstage/plugin-permission-common": ^0.8.1
+    "@backstage/plugin-search-common": ^1.2.14
+  checksum: 291a589cfa6d6d06dbb01d6343c005f4dad1d837b3f2d56ce7d0f1cb89b90c92af4e1dd17931cdcd2b6666b11eba0f8726f9fe02bca2340997002b2182cdf40b
   languageName: node
   linkType: hard
 
@@ -4050,22 +4115,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@npm:^1.12.0":
-  version: 1.12.0
-  resolution: "@backstage/plugin-catalog-react@npm:1.12.0"
+"@backstage/plugin-catalog-react@npm:^1.12.0, @backstage/plugin-catalog-react@npm:^1.13.0":
+  version: 1.13.0
+  resolution: "@backstage/plugin-catalog-react@npm:1.13.0"
   dependencies:
-    "@backstage/catalog-client": ^1.6.5
-    "@backstage/catalog-model": ^1.5.0
-    "@backstage/core-components": ^0.14.7
-    "@backstage/core-plugin-api": ^1.9.2
+    "@backstage/catalog-client": ^1.7.0
+    "@backstage/catalog-model": ^1.7.0
+    "@backstage/core-compat-api": ^0.3.0
+    "@backstage/core-components": ^0.15.0
+    "@backstage/core-plugin-api": ^1.9.4
     "@backstage/errors": ^1.2.4
-    "@backstage/frontend-plugin-api": ^0.6.5
-    "@backstage/integration-react": ^1.1.27
-    "@backstage/plugin-catalog-common": ^1.0.23
-    "@backstage/plugin-permission-common": ^0.7.13
-    "@backstage/plugin-permission-react": ^0.4.22
+    "@backstage/frontend-plugin-api": ^0.8.0
+    "@backstage/integration-react": ^1.1.31
+    "@backstage/plugin-catalog-common": ^1.1.0
+    "@backstage/plugin-permission-common": ^0.8.1
+    "@backstage/plugin-permission-react": ^0.4.26
     "@backstage/types": ^1.1.1
-    "@backstage/version-bridge": ^1.0.8
+    "@backstage/version-bridge": ^1.0.9
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
@@ -4082,7 +4148,7 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 8079c6c1f4c5b07df5cfb2873f4c3ba16759a3a1ac36a1e1ff61fb428cece5baca40b5c2bc41a2d402ad9a60e73fd545c0a95eec274189423f40a04551a5f337
+  checksum: e86fdfdab9f2b0fcbc68b0521acbc3c2ba95ab4206aabb09f307021960776f0aca6335cdb47b27c506b4a32f88768716839fe1e09e156d8970414da94992f0b9
   languageName: node
   linkType: hard
 
@@ -4144,6 +4210,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-permission-common@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "@backstage/plugin-permission-common@npm:0.8.1"
+  dependencies:
+    "@backstage/config": ^1.2.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/types": ^1.1.1
+    cross-fetch: ^4.0.0
+    uuid: ^9.0.0
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
+  checksum: 00f71b998aecefcf413b335ef67897be2210f9cecb1f58bb28e466f68acd04276e3105f2e99ad242792dfd2902e4ae7ea023efb8cda92447aef92a10b83d87e5
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-permission-node@npm:^0.7.29":
   version: 0.7.29
   resolution: "@backstage/plugin-permission-node@npm:0.7.29"
@@ -4163,30 +4244,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-react@npm:^0.4.22":
-  version: 0.4.22
-  resolution: "@backstage/plugin-permission-react@npm:0.4.22"
+"@backstage/plugin-permission-react@npm:^0.4.22, @backstage/plugin-permission-react@npm:^0.4.26":
+  version: 0.4.26
+  resolution: "@backstage/plugin-permission-react@npm:0.4.26"
   dependencies:
     "@backstage/config": ^1.2.0
-    "@backstage/core-plugin-api": ^1.9.2
-    "@backstage/plugin-permission-common": ^0.7.13
+    "@backstage/core-plugin-api": ^1.9.4
+    "@backstage/plugin-permission-common": ^0.8.1
     "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
     swr: ^2.0.0
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: c91ad5a336358ae3a2e6030e7ea7a8584735544a14aa6ada061ca0c01ee32b2e16bd2fe24c9327cbdb959eec185bac045b1211b0a03a5c9d45b350f0a6c031ca
+  checksum: ad7901bfbe10e637be017ecef55b1e2db9d9e83bde7e81b742f44e2bd71a0f24c7b27e651653b6654938a5c13729b5a89183cd9518f447c445688c052f3698d9
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-common@npm:^1.2.11":
-  version: 1.2.11
-  resolution: "@backstage/plugin-search-common@npm:1.2.11"
+"@backstage/plugin-search-common@npm:^1.2.14":
+  version: 1.2.14
+  resolution: "@backstage/plugin-search-common@npm:1.2.14"
   dependencies:
-    "@backstage/plugin-permission-common": ^0.7.13
+    "@backstage/plugin-permission-common": ^0.8.1
     "@backstage/types": ^1.1.1
-  checksum: 861ba64fd733511bad58d2b3f6b2af60426d71b8e8d74838b85a15a5870d54c0de984681a33f5adb8e97284da9167655982bcf5e543436d0f4160a2c0cbece1f
+  checksum: e4e44c06aaabfa296c9f07b6d9537bebcdbc54c309dcfbe9b11ee2625193df1571f58469388b49379a5a0fa1cc6560b81347dc4020b239b118558ae4d0c79511
   languageName: node
   linkType: hard
 
@@ -4278,9 +4359,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@npm:^0.5.4":
-  version: 0.5.4
-  resolution: "@backstage/theme@npm:0.5.4"
+"@backstage/theme@npm:^0.5.4, @backstage/theme@npm:^0.5.7":
+  version: 0.5.7
+  resolution: "@backstage/theme@npm:0.5.7"
   dependencies:
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
@@ -4290,7 +4371,7 @@ __metadata:
     "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: cc7424008970ffd1668f6288ae49e78b750ce164ba0ab5afb4e6b6a54e3bdaea6161ebf81a2f00deffa45d94a9601a09b63287d34771399fce16638f42b9f7b9
+  checksum: 5a315a198481f7b0c6f1a11bc102c36d2976cae25184ce6e28e6e44ce4a742e4d4416f19c71ac44f574a2745e30d13508a6c152f00e1facdef9c9d12dc3d0449
   languageName: node
   linkType: hard
 
@@ -4301,16 +4382,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/version-bridge@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "@backstage/version-bridge@npm:1.0.8"
+"@backstage/version-bridge@npm:^1.0.8, @backstage/version-bridge@npm:^1.0.9":
+  version: 1.0.9
+  resolution: "@backstage/version-bridge@npm:1.0.9"
   dependencies:
     "@types/react": ^16.13.1 || ^17.0.0
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: bf74cd70af7c23558d26637a90ed1ffe52449396a9759cbbb0f87f3517c6a2a760140c2723c8aabeb2e94b436e02110e78763e262293a88b37e15e622753f23a
+  checksum: eb805a747c66a9c78654109d6774d5a7c16175240fe9441c71800d7b2b9965e6e04960af902cbaf4fc9eb15e9c665888cf6e1b7c4e4f157c8617873999545c0f
   languageName: node
   linkType: hard
 
@@ -4455,6 +4536,7 @@ __metadata:
     "@backstage/core-components": ^0.14.7
     "@backstage/core-plugin-api": ^1.9.2
     "@backstage/dev-utils": ^1.0.32
+    "@backstage/plugin-catalog-react": ^1.13.0
     "@backstage/test-utils": ^1.5.5
     "@backstage/theme": ^0.5.4
     "@material-ui/core": ^4.9.13
@@ -25005,6 +25087,7 @@ __metadata:
   dependencies:
     "@backstage/cli": ^0.26.5
     "@backstage/e2e-test-utils": ^0.1.1
+    "@backstage/plugin-catalog-react": ^1.13.0
     "@backstage/repo-tools": ^0.9.0
     "@hookform/resolvers": ^3.3.2
     "@playwright/test": ^1.32.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -4564,7 +4564,9 @@ __metadata:
     msw: ^1.0.0
     mui-modal-provider: 2.2.0
     node-fetch: ^2.6.7
+    query-string: 7.0.0
     react-apexcharts: 1.4.1
+    recharts: ^2.12.7
     uuid: 10.0.0
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -9047,6 +9049,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/d3-array@npm:^3.0.3":
+  version: 3.2.1
+  resolution: "@types/d3-array@npm:3.2.1"
+  checksum: 8a41cee0969e53bab3f56cc15c4e6c9d76868d6daecb2b7d8c9ce71e0ececccc5a8239697cc52dadf5c665f287426de5c8ef31a49e7ad0f36e8846889a383df4
+  languageName: node
+  linkType: hard
+
 "@types/d3-color@npm:*, @types/d3-color@npm:^3.1.3":
   version: 3.1.3
   resolution: "@types/d3-color@npm:3.1.3"
@@ -9061,7 +9070,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-interpolate@npm:^3.0.4":
+"@types/d3-ease@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "@types/d3-ease@npm:3.0.2"
+  checksum: 0885219966294bfc99548f37297e1c75e75da812a5f3ec941977ebb57dcab0a25acec5b2bbd82d09a49d387daafca08521ca269b7e4c27ddca7768189e987b54
+  languageName: node
+  linkType: hard
+
+"@types/d3-interpolate@npm:^3.0.1, @types/d3-interpolate@npm:^3.0.4":
   version: 3.0.4
   resolution: "@types/d3-interpolate@npm:3.0.4"
   dependencies:
@@ -9077,7 +9093,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-scale@npm:^4.0.8":
+"@types/d3-scale@npm:^4.0.2, @types/d3-scale@npm:^4.0.8":
   version: 4.0.8
   resolution: "@types/d3-scale@npm:4.0.8"
   dependencies:
@@ -9086,7 +9102,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-shape@npm:^3.1.6":
+"@types/d3-shape@npm:^3.1.0, @types/d3-shape@npm:^3.1.6":
   version: 3.1.6
   resolution: "@types/d3-shape@npm:3.1.6"
   dependencies:
@@ -9095,10 +9111,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-time@npm:*, @types/d3-time@npm:^3.0.3":
+"@types/d3-time@npm:*, @types/d3-time@npm:^3.0.0, @types/d3-time@npm:^3.0.3":
   version: 3.0.3
   resolution: "@types/d3-time@npm:3.0.3"
   checksum: a071826c80efdb1999e6406fef2db516d45f3906da3a9a4da8517fa863bae53c4c1056ca5347a20921660607d21ec874fd2febe0e961adb7be6954255587d08f
+  languageName: node
+  linkType: hard
+
+"@types/d3-timer@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "@types/d3-timer@npm:3.0.2"
+  checksum: 1643eebfa5f4ae3eb00b556bbc509444d88078208ec2589ddd8e4a24f230dd4cf2301e9365947e70b1bee33f63aaefab84cd907822aae812b9bc4871b98ab0e1
   languageName: node
   linkType: hard
 
@@ -12201,7 +12224,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^2.1.0, clsx@npm:^2.1.1":
+"clsx@npm:^2.0.0, clsx@npm:^2.1.0, clsx@npm:^2.1.1":
   version: 2.1.1
   resolution: "clsx@npm:2.1.1"
   checksum: acd3e1ab9d8a433ecb3cc2f6a05ab95fe50b4a3cfc5ba47abb6cbf3754585fcb87b84e90c822a1f256c4198e3b41c7f6c391577ffc8678ad587fc0976b24fd57
@@ -13295,7 +13318,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3":
+"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:^3.1.6":
   version: 3.2.4
   resolution: "d3-array@npm:3.2.4"
   dependencies:
@@ -13337,7 +13360,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-ease@npm:1 - 3":
+"d3-ease@npm:1 - 3, d3-ease@npm:^3.0.1":
   version: 3.0.1
   resolution: "d3-ease@npm:3.0.1"
   checksum: 06e2ee5326d1e3545eab4e2c0f84046a123dcd3b612e68858219aa034da1160333d9ce3da20a1d3486d98cb5c2a06f7d233eee1bc19ce42d1533458bd85dedcd
@@ -13387,7 +13410,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-shape@npm:^3.0.0, d3-shape@npm:^3.2.0":
+"d3-shape@npm:^3.0.0, d3-shape@npm:^3.1.0, d3-shape@npm:^3.2.0":
   version: 3.2.0
   resolution: "d3-shape@npm:3.2.0"
   dependencies:
@@ -13405,7 +13428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:^3.1.0":
+"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:^3.0.0, d3-time@npm:^3.1.0":
   version: 3.1.0
   resolution: "d3-time@npm:3.1.0"
   dependencies:
@@ -13414,7 +13437,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-timer@npm:1 - 3":
+"d3-timer@npm:1 - 3, d3-timer@npm:^3.0.1":
   version: 3.0.1
   resolution: "d3-timer@npm:3.0.1"
   checksum: 1cfddf86d7bca22f73f2c427f52dfa35c49f50d64e187eb788dcad6e927625c636aa18ae4edd44d084eb9d1f81d8ca4ec305dae7f733c15846a824575b789d73
@@ -13603,6 +13626,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decimal.js-light@npm:^2.4.1":
+  version: 2.5.1
+  resolution: "decimal.js-light@npm:2.5.1"
+  checksum: f5a2c7eac1c4541c8ab8a5c8abea64fc1761cefc7794bd5f8afd57a8a78d1b51785e0c4e4f85f4895a043eaa90ddca1edc3981d1263eb6ddce60f32bf5fe66c9
+  languageName: node
+  linkType: hard
+
 "decimal.js@npm:^10.4.2":
   version: 10.4.3
   resolution: "decimal.js@npm:10.4.3"
@@ -13616,6 +13646,13 @@ __metadata:
   dependencies:
     character-entities: ^2.0.0
   checksum: f4c71d3b93105f20076052f9cb1523a22a9c796b8296cd35eef1ca54239c78d182c136a848b83ff8da2071e3ae2b1d300bf29d00650a6d6e675438cc31b11d78
+  languageName: node
+  linkType: hard
+
+"decode-uri-component@npm:^0.2.0":
+  version: 0.2.2
+  resolution: "decode-uri-component@npm:0.2.2"
+  checksum: 95476a7d28f267292ce745eac3524a9079058bbb35767b76e3ee87d42e34cd0275d2eb19d9d08c3e167f97556e8a2872747f5e65cbebcac8b0c98d83e285f139
   languageName: node
   linkType: hard
 
@@ -15127,7 +15164,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^4.0.0, eventemitter3@npm:^4.0.4":
+"eventemitter3@npm:^4.0.0, eventemitter3@npm:^4.0.1, eventemitter3@npm:^4.0.4":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
@@ -15355,6 +15392,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-equals@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "fast-equals@npm:5.0.1"
+  checksum: fbb3b6a74f3a0fa930afac151ff7d01639159b4fddd2678b5d50708e0ba38e9ec14602222d10dadb8398187342692c04fbef5a62b1cfcc7942fe03e754e064bc
+  languageName: node
+  linkType: hard
+
 "fast-fifo@npm:^1.1.0, fast-fifo@npm:^1.2.0":
   version: 1.3.2
   resolution: "fast-fifo@npm:1.3.2"
@@ -15543,6 +15587,13 @@ __metadata:
   dependencies:
     to-regex-range: ^5.0.1
   checksum: cc283f4e65b504259e64fd969bcf4def4eb08d85565e906b7d36516e87819db52029a76b6363d0f02d0d532f0033c9603b9e2d943d56ee3b0d4f7ad3328ff917
+  languageName: node
+  linkType: hard
+
+"filter-obj@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "filter-obj@npm:1.1.0"
+  checksum: cf2104a7c45ff48e7f505b78a3991c8f7f30f28bd8106ef582721f321f1c6277f7751aacd5d83026cb079d9d5091082f588d14a72e7c5d720ece79118fa61e10
   languageName: node
   linkType: hard
 
@@ -23778,6 +23829,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"query-string@npm:7.0.0":
+  version: 7.0.0
+  resolution: "query-string@npm:7.0.0"
+  dependencies:
+    decode-uri-component: ^0.2.0
+    filter-obj: ^1.1.0
+    split-on-first: ^1.0.0
+    strict-uri-encode: ^2.0.0
+  checksum: 6e3c4376ff01f49bf2300b36e37291e2d3be8df4fe1839d048dd89d4166b92ecd67525c88ca66b61cbc5612ca29fa4e40002d25a74f59b99f7022045b9e7abd2
+  languageName: node
+  linkType: hard
+
 "querystring-es3@npm:^0.2.0":
   version: 0.2.1
   resolution: "querystring-es3@npm:0.2.1"
@@ -24036,7 +24099,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
+"react-is@npm:^16.10.2, react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
@@ -24160,6 +24223,20 @@ __metadata:
   peerDependencies:
     react: ^16.3.0 || ^17.0.0 || ^18.0.0
   checksum: c5eb1f42b464fb093bca59aaae0f1b2060373a2aaff95275b8781493628cdbbb6acdd6014e7883782c65c361f35a30f28cc515d68a1263ddb39cbbc47110be53
+  languageName: node
+  linkType: hard
+
+"react-smooth@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "react-smooth@npm:4.0.1"
+  dependencies:
+    fast-equals: ^5.0.1
+    prop-types: ^15.8.1
+    react-transition-group: ^4.4.5
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 42c17803dcb3892a284bbb692d745d438e3bb204ecfc3c9f4f3ff808253ab783f6c64de85a0e84a20c2ea20cf0af39e78b947417ced328164d8dd4eca2918e01
   languageName: node
   linkType: hard
 
@@ -24416,6 +24493,34 @@ __metadata:
   dependencies:
     picomatch: ^2.2.1
   checksum: 1ced032e6e45670b6d7352d71d21ce7edf7b9b928494dcaba6f11fba63180d9da6cd7061ebc34175ffda6ff529f481818c962952004d273178acd70f7059b320
+  languageName: node
+  linkType: hard
+
+"recharts-scale@npm:^0.4.4":
+  version: 0.4.5
+  resolution: "recharts-scale@npm:0.4.5"
+  dependencies:
+    decimal.js-light: ^2.4.1
+  checksum: e970377190a610e684a32c7461c7684ac3603c2e0ac0020bbba1eea9d099b38138143a8e80bf769bb49c0b7cecf22a2f5c6854885efed2d56f4540d4aa7052bd
+  languageName: node
+  linkType: hard
+
+"recharts@npm:^2.12.7":
+  version: 2.12.7
+  resolution: "recharts@npm:2.12.7"
+  dependencies:
+    clsx: ^2.0.0
+    eventemitter3: ^4.0.1
+    lodash: ^4.17.21
+    react-is: ^16.10.2
+    react-smooth: ^4.0.0
+    recharts-scale: ^0.4.4
+    tiny-invariant: ^1.3.1
+    victory-vendor: ^36.6.8
+  peerDependencies:
+    react: ^16.0.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: c6f6b6d7de51dde17827f77f5dadfa0548422b1aa55c79d7104606dc47f8f4aabd7c6a226d9a8f6edf863788f33c99aafead784c842d2852b2bd9dac176460ea
   languageName: node
   linkType: hard
 
@@ -25907,6 +26012,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"split-on-first@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "split-on-first@npm:1.1.0"
+  checksum: 16ff85b54ddcf17f9147210a4022529b343edbcbea4ce977c8f30e38408b8d6e0f25f92cd35b86a524d4797f455e29ab89eb8db787f3c10708e0b47ebf528d30
+  languageName: node
+  linkType: hard
+
 "split2@npm:^3.2.2":
   version: 3.2.2
   resolution: "split2@npm:3.2.2"
@@ -26188,6 +26300,13 @@ __metadata:
   version: 0.4.6
   resolution: "strict-event-emitter@npm:0.4.6"
   checksum: 4f4f2909613e7811de789991c06bfb770d6d6987e2ec5c66fa7485d0f07cc4e7e32eba0dcf26cee6d86af6c92946d7f4acdfaff57d0c4114df2cfa1bf0e3c091
+  languageName: node
+  linkType: hard
+
+"strict-uri-encode@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "strict-uri-encode@npm:2.0.0"
+  checksum: eaac4cf978b6fbd480f1092cab8b233c9b949bcabfc9b598dd79a758f7243c28765ef7639c876fa72940dac687181b35486ea01ff7df3e65ce3848c64822c581
   languageName: node
   linkType: hard
 
@@ -26930,7 +27049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.0.6":
+"tiny-invariant@npm:^1.0.6, tiny-invariant@npm:^1.3.1":
   version: 1.3.3
   resolution: "tiny-invariant@npm:1.3.3"
   checksum: 5e185c8cc2266967984ce3b352a4e57cb89dad5a8abb0dea21468a6ecaa67cd5bb47a3b7a85d08041008644af4f667fb8b6575ba38ba5fb00b3b5068306e59fe
@@ -28137,6 +28256,28 @@ __metadata:
     unist-util-stringify-position: ^3.0.0
     vfile-message: ^3.0.0
   checksum: 642cce703afc186dbe7cabf698dc954c70146e853491086f5da39e1ce850676fc96b169fcf7898aa3ff245e9313aeec40da93acd1e1fcc0c146dc4f6308b4ef9
+  languageName: node
+  linkType: hard
+
+"victory-vendor@npm:^36.6.8":
+  version: 36.9.2
+  resolution: "victory-vendor@npm:36.9.2"
+  dependencies:
+    "@types/d3-array": ^3.0.3
+    "@types/d3-ease": ^3.0.0
+    "@types/d3-interpolate": ^3.0.1
+    "@types/d3-scale": ^4.0.2
+    "@types/d3-shape": ^3.1.0
+    "@types/d3-time": ^3.0.0
+    "@types/d3-timer": ^3.0.0
+    d3-array: ^3.1.6
+    d3-ease: ^3.0.1
+    d3-interpolate: ^3.0.1
+    d3-scale: ^4.0.2
+    d3-shape: ^3.1.0
+    d3-time: ^3.0.0
+    d3-timer: ^3.0.1
+  checksum: a755110e287b700202d08ac81982093ab100edaa9d61beef1476d59e9705605bd8299a3aa41fa04b933a12bd66737f4c8f7d18448dd6488c69d4f72480023a2e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4530,6 +4530,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@electrolux-oss/plugin-infrawallet@workspace:plugins/infrawallet"
   dependencies:
+    "@backstage/catalog-model": ^1.7.0
     "@backstage/cli": ^0.26.5
     "@backstage/config": ^1.2.0
     "@backstage/core-app-api": ^1.12.5
@@ -25190,6 +25191,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root@workspace:."
   dependencies:
+    "@backstage/catalog-model": ^1.7.0
     "@backstage/cli": ^0.26.5
     "@backstage/e2e-test-utils": ^0.1.1
     "@backstage/plugin-catalog-react": ^1.13.0


### PR DESCRIPTION
Hi @gluckzhang @emillg 

This PR Adds `EntityInfraWalletCard` 
Closes https://github.com/electrolux-oss/infrawallet/issues/44

this adds a sample entityCard to respective components for gcp-projects-ids in particular. 

it fetches the gcp-project-id in two ways currently: 
- if a entity contains the annotation of `infrawallet.io/gcp-project-ids: gcp-project-idA, gcp-project-idB`
- if a components contains a depnendsOn entity that is `Kind: Resource` and `Type: gcp-project`  ( this method is a more native method to handle gcp-projects in backstage, it assumes the user has already import their organizations gcp projects into backstage catalog, and the user can directly link their systems and components to use dependsOn : gcp-project so that a seperate annotation is not needed. This is good for there are already scaffolder workflows that auto map gcp project when provisioning new services, cost related data will automatically be added on without live patching a catalog-info.yaml file and finding its related gcp-project. 



As you can see, I currently have a very basic mockup just for debugging purposes, thus there isnt too much going on the UI. 

the query i sent to the backend is 

```

"GET /api/infrawallet/reports?&filters=(gcp_project_id=backstage-dev)&tags=()&groups=&granularity=monthly&startTime=1724343492212&endTime=1727021892212 HTTP/1.1" 200 - "http://localhost:3000/"
```

but as you can see from the UI, it resolved a cost info per service (for pretty much every gcp-project id) 

im assuming the backend isnt setup to just handle query of just a specific gcp cost data and is made available for the api client to use yet. How do you suggest i move forward? Should i be using another existing API instead or just build one specific for gcp? 


also the current flow seems to trigger a new job per each entity that has a gcp project. I think that is uneconomical , can i re-use the first job being ran via the main infrawallet plugin api call, re-use that data for every entity, then only selectively update per entity data only when the main plugin get an update? If you agree with such method, please point me to right place you would recommend me to add it. 

<img width="732" alt="Screenshot 2024-09-23 at 00 38 35" src="https://github.com/user-attachments/assets/fff8e983-ce7f-47cf-bc69-010fc81e920a">
