### PR TITLE
provide a cloudformation template for deploying InfraWallet demo site

### DIFF
--- a/app-config.infrawallet.yaml
+++ b/app-config.infrawallet.yaml
@@ -1,4 +1,9 @@
+app:
+  title: Backstage - InfraWallet
+  baseUrl: http://${INFRAWALLET_DOMAIN} # in our Dockerfile, we set the default value to localhost
+
 backend:
+  baseUrl: http://${INFRAWALLET_DOMAIN}
   infraWallet:
     metricProviders:
       mock:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -1,5 +1,5 @@
 app:
-  title: Backstage
+  title: Backstage - InfraWallet
   baseUrl: http://localhost:3000
 
 backend:
@@ -21,6 +21,7 @@ backend:
     # host: 127.0.0.1
   csp:
     connect-src: ["'self'", 'http:', 'https:']
+    upgrade-insecure-requests: false # allow access this demo instance via http
     # Content-Security-Policy directives follow the Helmet format: https://helmetjs.github.io/#reference
     # Default Helmet Content-Security-Policy values can be removed by setting the key to false
   cors:

--- a/docs/infrawallet-cloudformation.yaml
+++ b/docs/infrawallet-cloudformation.yaml
@@ -1,0 +1,224 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Infrastructure for InfraWallet
+
+Resources:
+  # VPC
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: InfraWalletVPC
+
+  # Subnet 1
+  Subnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 10.0.1.0/24
+      MapPublicIpOnLaunch: true
+      AvailabilityZone: !Select [0, !GetAZs 'eu-central-1']
+      Tags:
+        - Key: Name
+          Value: InfraWalletVPCSubnet1
+
+  # Subnet 2
+  Subnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 10.0.2.0/24
+      MapPublicIpOnLaunch: true
+      AvailabilityZone: !Select [1, !GetAZs 'eu-central-1']
+      Tags:
+        - Key: Name
+          Value: InfraWalletVPCSubnet2
+
+  # Internet Gateway
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: InfraWalletInternetGateway
+
+  # Attach Internet Gateway to VPC
+  AttachGateway:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
+  # Route Table
+  RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: InfraWalletVPCRouteTable
+
+  # Route
+  Route:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref RouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  # Subnet Route Table Association 1
+  SubnetRouteTableAssociation1:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref Subnet1
+      RouteTableId: !Ref RouteTable
+
+  # Subnet Route Table Association 2
+  SubnetRouteTableAssociation2:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref Subnet2
+      RouteTableId: !Ref RouteTable
+
+  # Security Group
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow HTTP and HTTPS
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+
+  # ECS Cluster
+  ECSCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: InfraWalletECSCluster
+
+  # ECS Task Execution Role
+  ECSInfraWalletExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: AmazonECSTaskExecutionRolePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*:log-group:/ecs/infrawallet-container:*
+
+  # CloudWatch Log Group
+  CloudWatchLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /ecs/infrawallet-container
+      RetentionInDays: 7
+
+  # ECS Task Definition
+  ECSTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: InfraWalletTaskDefinition
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: '512'
+      Memory: '1024'
+      ExecutionRoleArn: !GetAtt ECSInfraWalletExecutionRole.Arn
+      ContainerDefinitions:
+        - Name: InfraWalletContainer
+          Image: opensourceelectrolux/infrawallet:latest
+          PortMappings:
+            - ContainerPort: 7007
+              HostPort: 7007
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref CloudWatchLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: infrawallet-container
+
+  # Application Load Balancer
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: InfraWalletLoadBalancer
+      Subnets:
+        - !Ref Subnet1
+        - !Ref Subnet2
+      SecurityGroups:
+        - !Ref SecurityGroup
+      Scheme: internet-facing
+      LoadBalancerAttributes:
+        - Key: idle_timeout.timeout_seconds
+          Value: '60'
+      Type: application
+
+  # Target Group
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: InfraWalletTargetGroup
+      Port: 7007
+      Protocol: HTTP
+      VpcId: !Ref VPC
+      HealthCheckProtocol: HTTP
+      HealthCheckPort: '7007'
+      HealthCheckPath: /
+      Matcher:
+        HttpCode: 200-399
+      TargetType: ip
+
+  # Listener
+  Listener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref TargetGroup
+
+  # ECS Service
+  ECSService:
+    Type: AWS::ECS::Service
+    DependsOn: Listener # Ensure the Listener is created before the service
+    Properties:
+      Cluster: !Ref ECSCluster
+      DesiredCount: 1
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          Subnets:
+            - !Ref Subnet1
+            - !Ref Subnet2
+          SecurityGroups:
+            - !Ref SecurityGroup
+      TaskDefinition: !Ref ECSTaskDefinition
+      LoadBalancers:
+        - ContainerName: InfraWalletContainer
+          ContainerPort: 7007
+          TargetGroupArn: !Ref TargetGroup

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -56,4 +56,8 @@ RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid
 COPY --chown=node:node packages/backend/dist/bundle.tar.gz app-config*.yaml ./
 RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
 
+# Set InfraWallet domain as an ENV variable, this can be useful later on when we would like to deploy InfraWallet using
+# a custom domain
+ENV INFRAWALLET_DOMAIN=localhost
+
 CMD ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.infrawallet.yaml"]


### PR DESCRIPTION
If a user uses AWS and wants to set up InfraWallet in their infrastructure, they can use this CloudFormation template to create required resources, including:
- Networking: VPC, VPC subnets, InternetGateway, route tables, etc.
- ECS (Elastic Container Service) cluster that runs InfraWallet (the Docker image is taken from our DockerHub repo)
- Application balancer that routes the traffic to the service

For now, it is an insecure demo website (because the configuration file in the Docker image only contains a mock integration) and the template does not have anything related to SSL certificates. I think it is a good starting point as later on, we can enable users to configure integrations via UI and make this cloudformation template production-ready.