### PR TITLE
#114 add custom cost management

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -4,6 +4,6 @@ _We are proud to recognize the organizations that have adopted InfraWallet to ma
 
 _If your organization uses InfraWallet, we'd love to have you listed! Simply submit a Pull Request to add your organization name to the list below._
 
-| Organization                                                | Contact(s)                                                              |
-|-------------------------------------------------------------|-------------------------------------------------------------------------|
-| [Electrolux](https://www.electrolux.com)                    | [@kondrashevich](https://github.com/kondrashevich)                      |
+| Organization                             | Contact(s)                                         |
+| ---------------------------------------- | -------------------------------------------------- |
+| [Electrolux](https://www.electrolux.com) | [@kondrashevich](https://github.com/kondrashevich) |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@
 
 \*_The framework is designed to be extensible to support other cloud providers. Feel free to [contribute](./docs/contributing.md) to the project._
 
+\*\*_You can also manually add custom costs using InfraWallet UI if there is no integration. See more about this feature on this [page](./docs/getting-started.md#custom-costs-management)._
+
 ## Getting started
 
 To start using InfraWallet, see the [Getting Started documentation](./docs/getting-started.md).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![GitHub Release](https://img.shields.io/github/v/release/electrolux-oss/infrawallet)](https://github.com/electrolux-oss/infrawallet/releases)
 ![NPM Downloads](https://img.shields.io/npm/dm/%40electrolux-oss%2Fplugin-infrawallet)
 
-
 > Control your cloud costs just in the way how you control your bank accounts
 
 ![InfraWallet](./plugins/infrawallet/docs/images/iw_demo.gif)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,4 +3,3 @@
 ## Reporting Security Issues
 
 To report a security issue, please use ["Report a Vulnerability"](https://github.com/electrolux-oss/infrawallet/security/advisories/new).
-

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -195,17 +195,7 @@ Datadog doesn't provide daily costs. Current daily costs are calculated by `mont
 ### Custom Costs Management
 
 If there is no integration available for some of the cloud costs, it is possible to add such costs via InfraWallet
-custom cost management UI. To enable this feature, you only need to add the following configuration:
-
-```yaml
-backend:
-  infraWallet:
-    integrations:
-      custom:
-        - name: <arbitrary_string>
-```
-
-Then visit `/infrawallet/custom_costs` for managing custom costs. The big table on this page shows all of the custom
+custom cost management UI (the tab besides the cost tab). The big table on this page shows all of the custom
 costs saved in the plugin's database. For now, custom costs are only at the monthly level. When the granularity is set
 to `daily` in a view, there are amortization modes of transforming monthly custom costs into daily costs:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -192,6 +192,31 @@ backend:
 
 Datadog doesn't provide daily costs. Current daily costs are calculated by `monthly costs/number of days in that month`.
 
+### Custom Costs Management
+
+If there is no integration available for some of the cloud costs, it is possible to add such costs via InfraWallet
+custom cost management UI. To enable this feature, you only need to add the following configuration:
+
+```yaml
+backend:
+  infraWallet:
+    integrations:
+      custom:
+        - name: <arbitrary_string>
+```
+
+Then visit `/infrawallet/custom_costs` for managing custom costs. The big table on this page shows all of the custom
+costs saved in the plugin's database. For now, custom costs are only at the monthly level. When the granularity is set
+to `daily` in a view, there are amortization modes of transforming monthly custom costs into daily costs:
+
+- Average (by default): the monthly cost is divided by the number of days in that month
+- First day: the monthly cost is assigned to the first day of that month
+- End day: the monthly cost is assigned to the last day of that month
+
+If you would like to create multiple cost records for a provider, you can click the `BULK INSERT COSTS` button at the
+top left corner of the table. Then fill in the necessary information like provider, monthly cost, start month, end
+month, etc. Check the preview and click the `INSERT` button to save the records.
+
 ## Integration Filter
 
 When integrating InfraWallet with your billing account, you have the ability to retrieve and display costs for all sub-accounts. However, if you want to limit the visibility of certain accounts, you can apply filters. Below is an example of how to configure this for AWS:

--- a/plugins/infrawallet-backend/migrations/20241017141420_create-custom-cost-table.js
+++ b/plugins/infrawallet-backend/migrations/20241017141420_create-custom-cost-table.js
@@ -1,0 +1,31 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.createTable('custom_costs', table => {
+    table.comment('Custom costs uploaded by users');
+    table.uuid('id').defaultTo(knex.fn.uuid()).primary().notNullable().comment('Auto-generated ID of a record');
+    table.string('provider').notNullable().comment('The provider name of this cost');
+    table.string('account').notNullable().comment('The account name under this provider');
+    table.string('service').comment('The service name of this cost, can be blank');
+    table.string('category').comment('The category that this cost belongs to, can be blank');
+    table.string('currency').defaultTo('USD').comment('The currency of the cost, default to USD');
+    table
+      .string('amortization_mode')
+      .comment('How the monthly custom costs are mapped to daily costs, support two values: average, as_it_is');
+    table.integer('usage_month').comment('The usage month of the cost, format YYYYMM');
+    table.decimal('cost').comment('The value of the cost');
+    table
+      .json('tags')
+      .comment('Other tags that this cost record has, in json format such as {"tag_a":"value_a", "tag_b":"value_b"}');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.dropTableIfExists('custom_costs');
+};

--- a/plugins/infrawallet-backend/package.json
+++ b/plugins/infrawallet-backend/package.json
@@ -68,6 +68,7 @@
     "@backstage/plugin-auth-backend": "^0.23.0",
     "@backstage/plugin-auth-backend-module-guest-provider": "^0.2.0",
     "@types/supertest": "^2.0.8",
+    "knex": "^3.1.0",
     "msw": "^1.0.0",
     "supertest": "^6.2.4"
   },

--- a/plugins/infrawallet-backend/src/cost-clients/AwsClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/AwsClient.ts
@@ -264,6 +264,7 @@ export class AwsClient extends InfraWalletClient {
                 service: this.convertServiceName(serviceName),
                 category: categoryMappingService.getCategoryByServiceName(this.provider, serviceName),
                 provider: this.provider,
+                type: 'Integration',
                 reports: {},
                 ...tagKeyValues,
               };

--- a/plugins/infrawallet-backend/src/cost-clients/AwsClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/AwsClient.ts
@@ -264,7 +264,7 @@ export class AwsClient extends InfraWalletClient {
                 service: this.convertServiceName(serviceName),
                 category: categoryMappingService.getCategoryByServiceName(this.provider, serviceName),
                 provider: this.provider,
-                provider_type: PROVIDER_TYPE.INTEGRATION,
+                providerType: PROVIDER_TYPE.INTEGRATION,
                 reports: {},
                 ...tagKeyValues,
               };

--- a/plugins/infrawallet-backend/src/cost-clients/AwsClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/AwsClient.ts
@@ -15,7 +15,7 @@ import { Config } from '@backstage/config';
 import { reduce } from 'lodash';
 import moment from 'moment';
 import { CategoryMappingService } from '../service/CategoryMappingService';
-import { CLOUD_PROVIDER } from '../service/consts';
+import { CLOUD_PROVIDER, PROVIDER_TYPE } from '../service/consts';
 import { parseTags } from '../service/functions';
 import { CostQuery, Report, TagsQuery } from '../service/types';
 import { InfraWalletClient } from './InfraWalletClient';
@@ -264,7 +264,7 @@ export class AwsClient extends InfraWalletClient {
                 service: this.convertServiceName(serviceName),
                 category: categoryMappingService.getCategoryByServiceName(this.provider, serviceName),
                 provider: this.provider,
-                type: 'Integration',
+                provider_type: PROVIDER_TYPE.INTEGRATION,
                 reports: {},
                 ...tagKeyValues,
               };

--- a/plugins/infrawallet-backend/src/cost-clients/AzureClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/AzureClient.ts
@@ -252,6 +252,7 @@ export class AzureClient extends InfraWalletClient {
             service: this.convertServiceName(serviceName),
             category: categoryMappingService.getCategoryByServiceName(this.provider, serviceName),
             provider: this.provider,
+            type: 'Integration',
             reports: {},
             ...tagKeyValues,
           };

--- a/plugins/infrawallet-backend/src/cost-clients/AzureClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/AzureClient.ts
@@ -252,7 +252,7 @@ export class AzureClient extends InfraWalletClient {
             service: this.convertServiceName(serviceName),
             category: categoryMappingService.getCategoryByServiceName(this.provider, serviceName),
             provider: this.provider,
-            provider_type: PROVIDER_TYPE.INTEGRATION,
+            providerType: PROVIDER_TYPE.INTEGRATION,
             reports: {},
             ...tagKeyValues,
           };

--- a/plugins/infrawallet-backend/src/cost-clients/AzureClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/AzureClient.ts
@@ -6,7 +6,7 @@ import { Config } from '@backstage/config';
 import { reduce } from 'lodash';
 import moment from 'moment';
 import { CategoryMappingService } from '../service/CategoryMappingService';
-import { CLOUD_PROVIDER } from '../service/consts';
+import { CLOUD_PROVIDER, PROVIDER_TYPE } from '../service/consts';
 import { parseTags } from '../service/functions';
 import { CostQuery, Report, TagsQuery } from '../service/types';
 import { InfraWalletClient } from './InfraWalletClient';
@@ -252,7 +252,7 @@ export class AzureClient extends InfraWalletClient {
             service: this.convertServiceName(serviceName),
             category: categoryMappingService.getCategoryByServiceName(this.provider, serviceName),
             provider: this.provider,
-            type: 'Integration',
+            provider_type: PROVIDER_TYPE.INTEGRATION,
             reports: {},
             ...tagKeyValues,
           };

--- a/plugins/infrawallet-backend/src/cost-clients/ConfluentClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/ConfluentClient.ts
@@ -167,6 +167,7 @@ export class ConfluentClient extends InfraWalletClient {
           service: this.convertServiceName(serviceName),
           category: categoryMappingService.getCategoryByServiceName(this.provider, serviceName),
           provider: this.provider,
+          type: 'Integration',
           reports: {},
           ...{ project: envDisplayName },
           ...{ cluster: resourceName },

--- a/plugins/infrawallet-backend/src/cost-clients/ConfluentClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/ConfluentClient.ts
@@ -167,7 +167,7 @@ export class ConfluentClient extends InfraWalletClient {
           service: this.convertServiceName(serviceName),
           category: categoryMappingService.getCategoryByServiceName(this.provider, serviceName),
           provider: this.provider,
-          provider_type: PROVIDER_TYPE.INTEGRATION,
+          providerType: PROVIDER_TYPE.INTEGRATION,
           reports: {},
           ...{ project: envDisplayName },
           ...{ cluster: resourceName },

--- a/plugins/infrawallet-backend/src/cost-clients/ConfluentClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/ConfluentClient.ts
@@ -4,7 +4,7 @@ import { CostQuery, Report } from '../service/types';
 import { InfraWalletClient } from './InfraWalletClient';
 import moment from 'moment';
 import { CategoryMappingService } from '../service/CategoryMappingService';
-import { CLOUD_PROVIDER } from '../service/consts';
+import { CLOUD_PROVIDER, PROVIDER_TYPE } from '../service/consts';
 
 export class ConfluentClient extends InfraWalletClient {
   static create(config: Config, database: DatabaseService, cache: CacheService, logger: LoggerService) {
@@ -167,7 +167,7 @@ export class ConfluentClient extends InfraWalletClient {
           service: this.convertServiceName(serviceName),
           category: categoryMappingService.getCategoryByServiceName(this.provider, serviceName),
           provider: this.provider,
-          type: 'Integration',
+          provider_type: PROVIDER_TYPE.INTEGRATION,
           reports: {},
           ...{ project: envDisplayName },
           ...{ cluster: resourceName },

--- a/plugins/infrawallet-backend/src/cost-clients/CustomCostClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/CustomCostClient.ts
@@ -1,0 +1,96 @@
+import { CacheService, DatabaseService, LoggerService } from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config';
+import { reduce } from 'lodash';
+import moment from 'moment';
+import { getCustomCostsByDateRange } from '../models/CustomCost';
+import { CLOUD_PROVIDER, GRANULARITY } from '../service/consts';
+import { CostQuery, Report } from '../service/types';
+import { InfraWalletClient } from './InfraWalletClient';
+import { getDailyPeriodStringsForOneMonth } from '../service/functions';
+
+export class CustomCostClient extends InfraWalletClient {
+  static create(config: Config, database: DatabaseService, cache: CacheService, logger: LoggerService) {
+    return new CustomCostClient(CLOUD_PROVIDER.CUSTOM, config, database, cache, logger);
+  }
+
+  protected async initCloudClient(_config: Config): Promise<any> {
+    return null;
+  }
+
+  protected async fetchCosts(_integrationConfig: Config, _client: any, query: CostQuery): Promise<any> {
+    const records = getCustomCostsByDateRange(
+      this.database,
+      moment(parseInt(query.startTime, 10)).toDate(),
+      moment(parseInt(query.endTime, 10)).toDate(),
+    );
+    return records;
+  }
+
+  protected async transformCostsData(subAccountConfig: Config, query: CostQuery, costResponse: any): Promise<Report[]> {
+    const accountName = subAccountConfig.getString('name');
+
+    const transformedData = reduce(
+      costResponse,
+      (accumulator: { [key: string]: Report }, record) => {
+        let periodFormat = 'YYYY-MM';
+        if (query.granularity === GRANULARITY.DAILY) {
+          periodFormat = 'YYYY-MM-DD';
+        }
+
+        const keyName = `${accountName}-${record.provider}-${record.account}-${record.service}`;
+
+        // make it compatible with SQLite database
+        if (typeof record.tags === 'string') {
+          try {
+            record.tags = JSON.parse(record.tags);
+          } catch (error) {
+            this.logger.error(`Failed to parse tags for custom cost ${keyName}, tags: ${record.tags}`);
+            record.tags = {};
+          }
+        }
+
+        if (!accumulator[keyName]) {
+          accumulator[keyName] = {
+            id: keyName,
+            account: `${this.provider}/${accountName}`,
+            service: record.service,
+            category: record.category,
+            provider: record.provider,
+            type: 'Custom Cost',
+            reports: {},
+          };
+        }
+
+        // if custom costs with same provider+account+service values, but contain different tags
+        // we merge these tags, but the tag with same key will be overriden
+        accumulator[keyName] = { ...accumulator[keyName], ...record.tags };
+
+        const cost = parseFloat(record.cost);
+        if (query.granularity === GRANULARITY.MONTHLY) {
+          const period = moment(record.usage_month.toString(), 'YYYYMM').format(periodFormat);
+          accumulator[keyName].reports[period] = cost;
+        } else {
+          if (record.amortization_mode === 'average') {
+            // calculate the average daily cost
+            const periods = getDailyPeriodStringsForOneMonth(record.usage_month);
+            const averageCost = parseFloat(record.cost) / periods.length;
+            periods.forEach(period => {
+              accumulator[keyName].reports[period] = averageCost;
+            });
+          } else if (record.amortization_mode === 'start_day') {
+            const period = moment(record.usage_month.toString(), 'YYYYMM').startOf('month').format(periodFormat);
+            accumulator[keyName].reports[period] = cost;
+          } else {
+            const period = moment(record.usage_month.toString(), 'YYYYMM').endOf('month').format(periodFormat);
+            accumulator[keyName].reports[period] = cost;
+          }
+        }
+
+        return accumulator;
+      },
+      {},
+    );
+
+    return Object.values(transformedData);
+  }
+}

--- a/plugins/infrawallet-backend/src/cost-clients/CustomProviderClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/CustomProviderClient.ts
@@ -63,7 +63,7 @@ export class CustomProviderClient extends InfraWalletClient {
             service: record.service,
             category: record.category,
             provider: record.provider,
-            provider_type: PROVIDER_TYPE.CUSTOM,
+            providerType: PROVIDER_TYPE.CUSTOM,
             reports: {},
           };
         }

--- a/plugins/infrawallet-backend/src/cost-clients/CustomProviderClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/CustomProviderClient.ts
@@ -3,7 +3,7 @@ import { Config } from '@backstage/config';
 import { reduce } from 'lodash';
 import moment from 'moment';
 import { getCustomCostsByDateRange } from '../models/CustomCost';
-import { CACHE_CATEGORY, CLOUD_PROVIDER, GRANULARITY } from '../service/consts';
+import { CACHE_CATEGORY, CLOUD_PROVIDER, PROVIDER_TYPE, GRANULARITY } from '../service/consts';
 import {
   getDailyPeriodStringsForOneMonth,
   getDefaultCacheTTL,
@@ -13,9 +13,9 @@ import {
 import { ClientResponse, CloudProviderError, CostQuery, Report } from '../service/types';
 import { InfraWalletClient } from './InfraWalletClient';
 
-export class CustomCostClient extends InfraWalletClient {
+export class CustomProviderClient extends InfraWalletClient {
   static create(config: Config, database: DatabaseService, cache: CacheService, logger: LoggerService) {
-    return new CustomCostClient(CLOUD_PROVIDER.CUSTOM, config, database, cache, logger);
+    return new CustomProviderClient(CLOUD_PROVIDER.CUSTOM, config, database, cache, logger);
   }
 
   protected async initCloudClient(_config: Config): Promise<any> {
@@ -63,7 +63,7 @@ export class CustomCostClient extends InfraWalletClient {
             service: record.service,
             category: record.category,
             provider: record.provider,
-            type: 'Custom Cost',
+            provider_type: PROVIDER_TYPE.CUSTOM,
             reports: {},
           };
         }

--- a/plugins/infrawallet-backend/src/cost-clients/DatadogClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/DatadogClient.ts
@@ -3,7 +3,7 @@ import { Config } from '@backstage/config';
 import { v2 as datadogApiV2, client as datadogClient } from '@datadog/datadog-api-client';
 import { reduce } from 'lodash';
 import moment from 'moment';
-import { CLOUD_PROVIDER, GRANULARITY } from '../service/consts';
+import { CLOUD_PROVIDER, GRANULARITY, PROVIDER_TYPE } from '../service/consts';
 import { CostQuery, Report } from '../service/types';
 import { InfraWalletClient } from './InfraWalletClient';
 
@@ -212,7 +212,7 @@ export class DatadogClient extends InfraWalletClient {
                 service: `${this.convertServiceName(productName as string)} (${charge.chargeType})`,
                 category: 'Observability',
                 provider: this.provider,
-                type: 'Integration',
+                provider_type: PROVIDER_TYPE.INTEGRATION,
                 reports: {},
                 ...tagKeyValues,
               };

--- a/plugins/infrawallet-backend/src/cost-clients/DatadogClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/DatadogClient.ts
@@ -212,6 +212,7 @@ export class DatadogClient extends InfraWalletClient {
                 service: `${this.convertServiceName(productName as string)} (${charge.chargeType})`,
                 category: 'Observability',
                 provider: this.provider,
+                type: 'Integration',
                 reports: {},
                 ...tagKeyValues,
               };

--- a/plugins/infrawallet-backend/src/cost-clients/DatadogClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/DatadogClient.ts
@@ -212,7 +212,7 @@ export class DatadogClient extends InfraWalletClient {
                 service: `${this.convertServiceName(productName as string)} (${charge.chargeType})`,
                 category: 'Observability',
                 provider: this.provider,
-                provider_type: PROVIDER_TYPE.INTEGRATION,
+                providerType: PROVIDER_TYPE.INTEGRATION,
                 reports: {},
                 ...tagKeyValues,
               };

--- a/plugins/infrawallet-backend/src/cost-clients/GCPClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/GCPClient.ts
@@ -106,7 +106,7 @@ export class GCPClient extends InfraWalletClient {
             service: this.convertServiceName(row.service),
             category: categoryMappingService.getCategoryByServiceName(this.provider, row.service),
             provider: this.provider,
-            provider_type: PROVIDER_TYPE.INTEGRATION,
+            providerType: PROVIDER_TYPE.INTEGRATION,
             reports: {},
             ...{ project: row.project }, // TODO: how should we handle the project field? for now, we add project name as a field in the report
             ...tagKeyValues, // note that if there is a tag `project:foo` in config, it overrides the project field set above

--- a/plugins/infrawallet-backend/src/cost-clients/GCPClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/GCPClient.ts
@@ -106,6 +106,7 @@ export class GCPClient extends InfraWalletClient {
             service: this.convertServiceName(row.service),
             category: categoryMappingService.getCategoryByServiceName(this.provider, row.service),
             provider: this.provider,
+            type: 'Integration',
             reports: {},
             ...{ project: row.project }, // TODO: how should we handle the project field? for now, we add project name as a field in the report
             ...tagKeyValues, // note that if there is a tag `project:foo` in config, it overrides the project field set above

--- a/plugins/infrawallet-backend/src/cost-clients/GCPClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/GCPClient.ts
@@ -3,7 +3,7 @@ import { Config } from '@backstage/config';
 import { BigQuery } from '@google-cloud/bigquery';
 import { reduce } from 'lodash';
 import { CategoryMappingService } from '../service/CategoryMappingService';
-import { CLOUD_PROVIDER } from '../service/consts';
+import { CLOUD_PROVIDER, PROVIDER_TYPE } from '../service/consts';
 import { CostQuery, Report } from '../service/types';
 import { InfraWalletClient } from './InfraWalletClient';
 
@@ -106,7 +106,7 @@ export class GCPClient extends InfraWalletClient {
             service: this.convertServiceName(row.service),
             category: categoryMappingService.getCategoryByServiceName(this.provider, row.service),
             provider: this.provider,
-            type: 'Integration',
+            provider_type: PROVIDER_TYPE.INTEGRATION,
             reports: {},
             ...{ project: row.project }, // TODO: how should we handle the project field? for now, we add project name as a field in the report
             ...tagKeyValues, // note that if there is a tag `project:foo` in config, it overrides the project field set above

--- a/plugins/infrawallet-backend/src/cost-clients/MockClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/MockClient.ts
@@ -1,11 +1,11 @@
-import { promises as fsPromises } from 'fs';
-import moment from 'moment';
-import { CostQuery, Report } from '../service/types';
-import * as upath from 'upath';
-import { InfraWalletClient } from './InfraWalletClient';
 import { CacheService, DatabaseService, LoggerService, resolvePackagePath } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
-import { CLOUD_PROVIDER } from '../service/consts';
+import { promises as fsPromises } from 'fs';
+import moment from 'moment';
+import * as upath from 'upath';
+import { CLOUD_PROVIDER, PROVIDER_TYPE } from '../service/consts';
+import { CostQuery, Report } from '../service/types';
+import { InfraWalletClient } from './InfraWalletClient';
 
 export class MockClient extends InfraWalletClient {
   static create(config: Config, database: DatabaseService, cache: CacheService, logger: LoggerService) {
@@ -43,7 +43,7 @@ export class MockClient extends InfraWalletClient {
 
       const processedData = await Promise.all(
         jsonData.map(async item => {
-          item.type = 'Integration';
+          item.provider_type = PROVIDER_TYPE.INTEGRATION;
           item.reports = {};
 
           const StartDate = moment(startD);

--- a/plugins/infrawallet-backend/src/cost-clients/MockClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/MockClient.ts
@@ -43,7 +43,7 @@ export class MockClient extends InfraWalletClient {
 
       const processedData = await Promise.all(
         jsonData.map(async item => {
-          item.provider_type = PROVIDER_TYPE.INTEGRATION;
+          item.providerType = PROVIDER_TYPE.INTEGRATION;
           item.reports = {};
 
           const StartDate = moment(startD);

--- a/plugins/infrawallet-backend/src/cost-clients/MockClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/MockClient.ts
@@ -43,6 +43,7 @@ export class MockClient extends InfraWalletClient {
 
       const processedData = await Promise.all(
         jsonData.map(async item => {
+          item.type = 'Integration';
           item.reports = {};
 
           const StartDate = moment(startD);

--- a/plugins/infrawallet-backend/src/cost-clients/MongoAtlasClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/MongoAtlasClient.ts
@@ -169,7 +169,7 @@ export class MongoAtlasClient extends InfraWalletClient {
             service: this.convertServiceName(serviceName),
             category: categoryMappingService.getCategoryByServiceName(this.provider, serviceName),
             provider: this.provider,
-            provider_type: PROVIDER_TYPE.INTEGRATION,
+            providerType: PROVIDER_TYPE.INTEGRATION,
             reports: {},
             ...{ project: project },
             ...{ cluster: cluster },

--- a/plugins/infrawallet-backend/src/cost-clients/MongoAtlasClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/MongoAtlasClient.ts
@@ -4,7 +4,7 @@ import { reduce } from 'lodash';
 import moment from 'moment';
 import urllib from 'urllib';
 import { CategoryMappingService } from '../service/CategoryMappingService';
-import { CLOUD_PROVIDER } from '../service/consts';
+import { CLOUD_PROVIDER, PROVIDER_TYPE } from '../service/consts';
 import { CostQuery, Report } from '../service/types';
 import { InfraWalletClient } from './InfraWalletClient';
 
@@ -169,7 +169,7 @@ export class MongoAtlasClient extends InfraWalletClient {
             service: this.convertServiceName(serviceName),
             category: categoryMappingService.getCategoryByServiceName(this.provider, serviceName),
             provider: this.provider,
-            type: 'Integration',
+            provider_type: PROVIDER_TYPE.INTEGRATION,
             reports: {},
             ...{ project: project },
             ...{ cluster: cluster },

--- a/plugins/infrawallet-backend/src/cost-clients/MongoAtlasClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/MongoAtlasClient.ts
@@ -169,6 +169,7 @@ export class MongoAtlasClient extends InfraWalletClient {
             service: this.convertServiceName(serviceName),
             category: categoryMappingService.getCategoryByServiceName(this.provider, serviceName),
             provider: this.provider,
+            type: 'Integration',
             reports: {},
             ...{ project: project },
             ...{ cluster: cluster },

--- a/plugins/infrawallet-backend/src/models/CustomCost.ts
+++ b/plugins/infrawallet-backend/src/models/CustomCost.ts
@@ -1,0 +1,73 @@
+import { DatabaseService } from '@backstage/backend-plugin-api';
+import moment from 'moment';
+
+export type CustomCost = {
+  id: string; // UUID
+  provider: string;
+  account: string;
+  service?: string;
+  category?: string;
+  currency: string; // Default to 'USD'
+  amortization_mode: string; // average, start_day, or end_day
+  usage_month: number; // format YYYYMM
+  cost?: number;
+  tags?: Record<string, string>; // JSON object with key-value pairs
+};
+
+// Create a new cost record
+export async function createCustomCost(database: DatabaseService, data: Omit<CustomCost, 'id'>): Promise<CustomCost> {
+  const knex = await database.getClient();
+  const [record] = await knex('custom_costs').insert(data).returning('*');
+  return record;
+}
+
+// Create multiple cost records
+export async function createCustomCosts(database: DatabaseService, data: Omit<CustomCost, 'id'>[]): Promise<number> {
+  const knex = await database.getClient();
+  const records = await knex('custom_costs').insert(data).returning('id');
+  return records.length;
+}
+
+// Get cost records by date range
+export async function getCustomCostsByDateRange(
+  database: DatabaseService,
+  start_date: Date,
+  end_date: Date,
+): Promise<CustomCost[]> {
+  const knex = await database.getClient();
+
+  const records = await knex('custom_costs')
+    .whereBetween('usage_month', [
+      parseInt(moment(start_date).format('YYYYMM'), 10),
+      parseInt(moment(end_date).format('YYYYMM'), 10),
+    ])
+    .select('*');
+
+  return records;
+}
+
+// Get all cost records
+export async function getCustomCosts(database: DatabaseService): Promise<CustomCost[]> {
+  const knex = await database.getClient();
+  const records = await knex('custom_costs').select('*');
+  return records;
+}
+
+// Update one cost record
+export async function updateOrInsertCustomCost(database: DatabaseService, data: CustomCost): Promise<CustomCost> {
+  const knex = await database.getClient();
+  const [record] = await knex('custom_costs').insert(data).onConflict('id').merge().returning('*');
+  return record;
+}
+
+// Delete one cost record
+export async function deleteCustomCost(database: DatabaseService, data: CustomCost): Promise<boolean> {
+  const knex = await database.getClient();
+  const result: number = await knex('custom_costs').where('id', data.id).del();
+
+  if (result > 0) {
+    return true;
+  }
+
+  return false;
+}

--- a/plugins/infrawallet-backend/src/models/CustomCost.ts
+++ b/plugins/infrawallet-backend/src/models/CustomCost.ts
@@ -31,15 +31,15 @@ export async function createCustomCosts(database: DatabaseService, data: Omit<Cu
 // Get cost records by date range
 export async function getCustomCostsByDateRange(
   database: DatabaseService,
-  start_date: Date,
-  end_date: Date,
+  startDate: Date,
+  endDate: Date,
 ): Promise<CustomCost[]> {
   const knex = await database.getClient();
 
   const records = await knex('custom_costs')
     .whereBetween('usage_month', [
-      parseInt(moment(start_date).format('YYYYMM'), 10),
-      parseInt(moment(end_date).format('YYYYMM'), 10),
+      parseInt(moment(startDate).format('YYYYMM'), 10),
+      parseInt(moment(endDate).format('YYYYMM'), 10),
     ])
     .select('*');
 

--- a/plugins/infrawallet-backend/src/service/consts.ts
+++ b/plugins/infrawallet-backend/src/service/consts.ts
@@ -1,7 +1,7 @@
 import { AwsClient } from '../cost-clients/AwsClient';
 import { AzureClient } from '../cost-clients/AzureClient';
 import { ConfluentClient } from '../cost-clients/ConfluentClient';
-import { CustomCostClient } from '../cost-clients/CustomCostClient';
+import { CustomProviderClient } from '../cost-clients/CustomProviderClient';
 import { DatadogClient } from '../cost-clients/DatadogClient';
 import { GCPClient } from '../cost-clients/GCPClient';
 import { MockClient } from '../cost-clients/MockClient';
@@ -31,7 +31,7 @@ export const COST_CLIENT_MAPPINGS: {
   confluent: ConfluentClient,
   mongoatlas: MongoAtlasClient,
   datadog: DatadogClient,
-  custom: CustomCostClient,
+  custom: CustomProviderClient,
   mock: MockClient,
 };
 
@@ -82,3 +82,8 @@ export const DEFAULT_COSTS_CACHE_TTL: {
   [CLOUD_PROVIDER.CUSTOM]: 1, // do not cache custom costs since they are in the plugin database
   [CLOUD_PROVIDER.MOCK]: 0, // NOTE: 0 means never expired!
 };
+
+export const enum PROVIDER_TYPE {
+  INTEGRATION = 'Itegration',
+  CUSTOM = 'Custom',
+}

--- a/plugins/infrawallet-backend/src/service/consts.ts
+++ b/plugins/infrawallet-backend/src/service/consts.ts
@@ -1,6 +1,7 @@
 import { AwsClient } from '../cost-clients/AwsClient';
 import { AzureClient } from '../cost-clients/AzureClient';
 import { ConfluentClient } from '../cost-clients/ConfluentClient';
+import { CustomCostClient } from '../cost-clients/CustomCostClient';
 import { DatadogClient } from '../cost-clients/DatadogClient';
 import { GCPClient } from '../cost-clients/GCPClient';
 import { MockClient } from '../cost-clients/MockClient';
@@ -17,6 +18,7 @@ export const enum CLOUD_PROVIDER {
   MONGODB_ATLAS = 'MongoAtlas',
   CONFLUENT = 'Confluent',
   DATADOG = 'Datadog',
+  CUSTOM = 'Custom',
   MOCK = 'Mock',
 }
 
@@ -29,6 +31,7 @@ export const COST_CLIENT_MAPPINGS: {
   confluent: ConfluentClient,
   mongoatlas: MongoAtlasClient,
   datadog: DatadogClient,
+  custom: CustomCostClient,
   mock: MockClient,
 };
 
@@ -63,7 +66,8 @@ export const DEFAULT_TAGS_CACHE_TTL: {
   [CLOUD_PROVIDER.MONGODB_ATLAS]: 1 * 60 * 60 * 1000,
   [CLOUD_PROVIDER.CONFLUENT]: 1 * 60 * 60 * 1000,
   [CLOUD_PROVIDER.DATADOG]: 1 * 60 * 60 * 1000,
-  [CLOUD_PROVIDER.MOCK]: 0,
+  [CLOUD_PROVIDER.CUSTOM]: 1,
+  [CLOUD_PROVIDER.MOCK]: 0, // NOTE: 0 means never expired!
 };
 
 export const DEFAULT_COSTS_CACHE_TTL: {
@@ -75,5 +79,6 @@ export const DEFAULT_COSTS_CACHE_TTL: {
   [CLOUD_PROVIDER.MONGODB_ATLAS]: 2 * 60 * 60 * 1000,
   [CLOUD_PROVIDER.CONFLUENT]: 2 * 60 * 60 * 1000,
   [CLOUD_PROVIDER.DATADOG]: 2 * 60 * 60 * 1000,
-  [CLOUD_PROVIDER.MOCK]: 0,
+  [CLOUD_PROVIDER.CUSTOM]: 1, // do not cache custom costs since they are in the plugin database
+  [CLOUD_PROVIDER.MOCK]: 0, // NOTE: 0 means never expired!
 };

--- a/plugins/infrawallet-backend/src/service/functions.ts
+++ b/plugins/infrawallet-backend/src/service/functions.ts
@@ -1,6 +1,7 @@
 import { CacheService } from '@backstage/backend-plugin-api';
 import { CACHE_CATEGORY, CLOUD_PROVIDER, DEFAULT_COSTS_CACHE_TTL, DEFAULT_TAGS_CACHE_TTL } from './consts';
 import { CostQuery, Metric, MetricQuery, Report, Tag, TagsQuery } from './types';
+import moment from 'moment';
 
 // In URL, tags are defined in this format:
 // tags=(provider1:key1=value1 OR provider2:key2=value2)
@@ -239,4 +240,17 @@ export function parseFilters(filters: string): Record<string, string[]> {
   });
 
   return result;
+}
+
+export function getDailyPeriodStringsForOneMonth(yyyymm: number): string[] {
+  const dateOjb = moment(yyyymm.toString(), 'YYYYMM');
+  const startOfMonth = moment(dateOjb).startOf('month');
+  const endOfMonth = moment(dateOjb).endOf('month');
+  const periods: string[] = [];
+
+  for (let date = startOfMonth; date.isBefore(endOfMonth) || date.isSame(endOfMonth); date.add(1, 'day')) {
+    periods.push(date.format('YYYY-MM-DD'));
+  }
+
+  return periods;
 }

--- a/plugins/infrawallet/src/api/InfraWalletApi.ts
+++ b/plugins/infrawallet/src/api/InfraWalletApi.ts
@@ -1,6 +1,8 @@
 import { createApiRef } from '@backstage/core-plugin-api';
 import {
   CostReportsResponse,
+  CustomCost,
+  CustomCostsResponse,
   GetWalletResponse,
   MetricConfigsResponse,
   MetricSetting,
@@ -39,4 +41,8 @@ export interface InfraWalletApi {
     metricSetting: MetricSetting,
   ): Promise<{ deleted: boolean; status: number }>;
   getWalletByName(walletName: string): Promise<GetWalletResponse>;
+  getCustomCosts(): Promise<CustomCostsResponse>;
+  createCustomCosts(customCosts: Omit<CustomCost, 'id'>[]): Promise<{ created: number; status: number }>;
+  updateCustomCost(customCost: CustomCost): Promise<{ updated: boolean; status: number }>;
+  deleteCustomCost(customCost: CustomCost): Promise<{ deleted: boolean; status: number }>;
 }

--- a/plugins/infrawallet/src/api/InfraWalletApiClient.ts
+++ b/plugins/infrawallet/src/api/InfraWalletApiClient.ts
@@ -1,8 +1,11 @@
 import { ConfigApi, IdentityApi } from '@backstage/core-plugin-api';
 import fetch from 'node-fetch';
 import { InfraWalletApi } from './InfraWalletApi';
+import { tagsToString } from './functions';
 import {
   CostReportsResponse,
+  CustomCost,
+  CustomCostsResponse,
   GetWalletResponse,
   MetricConfigsResponse,
   MetricSetting,
@@ -11,7 +14,6 @@ import {
   Tag,
   TagResponse,
 } from './types';
-import { tagsToString } from './functions';
 
 /** @public */
 export class InfraWalletApiClient implements InfraWalletApi {
@@ -23,7 +25,7 @@ export class InfraWalletApiClient implements InfraWalletApi {
     this.backendUrl = options.configApi.getString('backend.baseUrl');
   }
 
-  async request(path: string, method?: string, payload?: Record<string, string | undefined>) {
+  async request(path: string, method?: string, payload?: Record<string, any>) {
     const url = `${this.backendUrl}/${path}`;
     const { token: idToken } = await this.identityApi.getCredentials();
     const headers: Record<string, string> = idToken ? { Authorization: `Bearer ${idToken}` } : {};
@@ -96,6 +98,7 @@ export class InfraWalletApiClient implements InfraWalletApi {
     const url = `api/infrawallet/${walletName}/metrics_setting`;
     return await this.request(url);
   }
+
   async updateWalletMetricSetting(
     walletName: string,
     metricSetting: MetricSetting,
@@ -110,5 +113,25 @@ export class InfraWalletApiClient implements InfraWalletApi {
   ): Promise<{ deleted: boolean; status: number }> {
     const url = `api/infrawallet/${walletName}/metrics_setting`;
     return await this.request(url, 'DELETE', metricSetting);
+  }
+
+  async getCustomCosts(): Promise<CustomCostsResponse> {
+    const url = `api/infrawallet/custom_costs`;
+    return await this.request(url);
+  }
+
+  async createCustomCosts(customCosts: Omit<CustomCost, 'id'>[]): Promise<{ created: number; status: number }> {
+    const url = `api/infrawallet/custom_costs`;
+    return await this.request(url, 'POST', customCosts);
+  }
+
+  async updateCustomCost(customCost: CustomCost): Promise<{ updated: boolean; status: number }> {
+    const url = `api/infrawallet/custom_cost`;
+    return await this.request(url, 'PUT', customCost);
+  }
+
+  async deleteCustomCost(customCost: CustomCost): Promise<{ deleted: boolean; status: number }> {
+    const url = `api/infrawallet/custom_cost`;
+    return await this.request(url, 'DELETE', customCost);
   }
 }

--- a/plugins/infrawallet/src/api/types.ts
+++ b/plugins/infrawallet/src/api/types.ts
@@ -87,3 +87,21 @@ export type GetWalletResponse = {
   data?: Wallet;
   status: number;
 };
+
+export type CustomCost = {
+  id: string; // UUID
+  provider: string;
+  account: string;
+  service?: string;
+  category?: string;
+  currency: string;
+  amortization_mode: string; // average, as_it_is
+  usage_month: number; // format YYYYMM
+  cost?: number;
+  tags?: Record<string, string>; // JSON object with key-value pairs
+};
+
+export type CustomCostsResponse = {
+  data?: CustomCost[];
+  status: number;
+};

--- a/plugins/infrawallet/src/components/CustomCostsComponent/BulkInsertButton.tsx
+++ b/plugins/infrawallet/src/components/CustomCostsComponent/BulkInsertButton.tsx
@@ -112,7 +112,7 @@ export const BulkInsertButton = (prop: { reloadFunction: any }) => {
   return (
     <React.Fragment>
       <Button startIcon={<LibraryAddIcon />} onClick={handleClickOpen}>
-        Bult Insert Costs
+        Bulk Insert Costs
       </Button>
       <Dialog component="form" fullWidth maxWidth="md" open={open} onClose={handleClose} onSubmit={handleSubmit}>
         <DialogTitle>Insert custom costs for the same provider.</DialogTitle>

--- a/plugins/infrawallet/src/components/CustomCostsComponent/BulkInsertButton.tsx
+++ b/plugins/infrawallet/src/components/CustomCostsComponent/BulkInsertButton.tsx
@@ -1,0 +1,276 @@
+import { alertApiRef, useApi } from '@backstage/core-plugin-api';
+import LibraryAddIcon from '@mui/icons-material/LibraryAdd';
+import Alert from '@mui/material/Alert';
+import Autocomplete from '@mui/material/Autocomplete';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormControl from '@mui/material/FormControl';
+import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TextField from '@mui/material/TextField';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import moment from 'moment';
+import * as React from 'react';
+import { infraWalletApiRef } from '../../api/InfraWalletApi';
+import { CustomCost } from '../../api/types';
+
+type BulkCustomCost = {
+  provider: string;
+  account: string;
+  service: string;
+  category: string;
+  from: Date;
+  to: Date;
+  monthlyCost: number;
+};
+
+export const BulkInsertButton = (prop: { reloadFunction: any }) => {
+  const infraWalletApi = useApi(infraWalletApiRef);
+  const alertApi = useApi(alertApiRef);
+  const [open, setOpen] = React.useState(false);
+  const [submittingForm, setSubmittingForm] = React.useState(false);
+  const [bulkCustomCost, setBulkCustomCost] = React.useState<BulkCustomCost>({
+    provider: '',
+    account: '',
+    service: '',
+    category: '',
+    from: new Date(),
+    to: new Date(),
+    monthlyCost: 0,
+  });
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    prop.reloadFunction();
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setBulkCustomCost({ ...bulkCustomCost, [event.target.name]: event.target.value });
+  };
+
+  const generateRecords = (): Omit<CustomCost, 'id'>[] => {
+    const fromDate = moment(bulkCustomCost.from);
+    const toDate = moment(bulkCustomCost.to);
+    const records = [];
+
+    const currentDate = fromDate.clone();
+
+    while (currentDate.isSameOrBefore(toDate, 'month')) {
+      const newRecord: Omit<CustomCost, 'id'> = {
+        provider: bulkCustomCost.provider,
+        account: bulkCustomCost.account,
+        service: bulkCustomCost.service,
+        category: bulkCustomCost.category,
+        currency: 'USD',
+        amortization_mode: 'average',
+        usage_month: parseInt(currentDate.format('YYYYMM'), 10),
+        cost: bulkCustomCost.monthlyCost,
+      };
+      records.push(newRecord);
+      currentDate.add(1, 'month');
+    }
+
+    return records;
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setSubmittingForm(true);
+    const records = generateRecords();
+    infraWalletApi
+      .createCustomCosts(records)
+      .then((response: any) => {
+        if (response.status === 200) {
+          alertApi.post({ message: 'Custom costs created', severity: 'info' });
+          setSubmittingForm(false);
+          setOpen(false);
+          prop.reloadFunction();
+        } else {
+          alertApi.post({ message: 'Failed to bulk insert the custom costs', severity: 'error' });
+          setSubmittingForm(false);
+        }
+      })
+      .catch(e => alertApi.post({ message: `${e.message}`, severity: 'error' }));
+  };
+
+  return (
+    <React.Fragment>
+      <Button startIcon={<LibraryAddIcon />} onClick={handleClickOpen}>
+        Bult Insert Costs
+      </Button>
+      <Dialog component="form" fullWidth maxWidth="md" open={open} onClose={handleClose} onSubmit={handleSubmit}>
+        <DialogTitle>Insert custom costs for the same provider.</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            You can insert custom monthly costs for a provider, if it is an anual contract for example.
+          </DialogContentText>
+          <Grid container spacing={3}>
+            <Grid item xs={12} md={6}>
+              <FormControl fullWidth sx={{ m: 1 }}>
+                <TextField
+                  id="provider-input"
+                  name="provider"
+                  label="Provider"
+                  value={bulkCustomCost.provider}
+                  onChange={handleChange}
+                  required
+                />
+              </FormControl>
+              <Grid container>
+                <Grid item xs={12} md={6}>
+                  <FormControl fullWidth sx={{ m: 1 }}>
+                    <TextField
+                      id="account-input"
+                      name="account"
+                      label="Account"
+                      value={bulkCustomCost.account}
+                      onChange={handleChange}
+                    />
+                  </FormControl>
+                </Grid>
+                <Grid item xs={12} md={6}>
+                  <FormControl fullWidth sx={{ m: 1 }}>
+                    <TextField
+                      id="service-input"
+                      name="service"
+                      label="Service"
+                      value={bulkCustomCost.service}
+                      onChange={handleChange}
+                    />
+                  </FormControl>
+                </Grid>
+              </Grid>
+              <FormControl fullWidth sx={{ m: 1 }}>
+                <Autocomplete
+                  id="category-input"
+                  freeSolo
+                  options={[
+                    'Uncategorized',
+                    'Analytics',
+                    'Application Integration',
+                    'Cloud Financial Management',
+                    'Compute',
+                    'Containers',
+                    'Database',
+                    'Developer Tools',
+                    'Front-End Web & Mobile',
+                    'Internet of Things',
+                    'Management & Governance',
+                    'Migration',
+                    'Networking',
+                    'Security, Identity, & Compliance',
+                    'Storage',
+                  ]}
+                  onChange={(_, value) => setBulkCustomCost({ ...bulkCustomCost, category: value as string })}
+                  renderInput={params => (
+                    <TextField {...params} name="category" onChange={handleChange} label="Category" />
+                  )}
+                />
+              </FormControl>
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <FormControl fullWidth sx={{ m: 1 }}>
+                <LocalizationProvider dateAdapter={AdapterDateFns}>
+                  <DatePicker
+                    value={bulkCustomCost.from}
+                    label="From"
+                    views={['year', 'month']}
+                    slotProps={{ textField: { variant: 'standard' } }}
+                    onAccept={value => {
+                      if (value) {
+                        setBulkCustomCost({ ...bulkCustomCost, from: value });
+                      }
+                    }}
+                  />
+                </LocalizationProvider>
+              </FormControl>
+              <FormControl fullWidth sx={{ m: 1 }}>
+                <LocalizationProvider dateAdapter={AdapterDateFns}>
+                  <DatePicker
+                    value={bulkCustomCost.to}
+                    label="To"
+                    views={['year', 'month']}
+                    slotProps={{ textField: { variant: 'standard' } }}
+                    onAccept={value => {
+                      if (value) {
+                        setBulkCustomCost({ ...bulkCustomCost, to: value });
+                      }
+                    }}
+                  />
+                </LocalizationProvider>
+              </FormControl>
+              <FormControl fullWidth sx={{ m: 1 }}>
+                <TextField
+                  id="monthly-cost-input"
+                  name="monthlyCost"
+                  variant="standard"
+                  type="number"
+                  label="Monthly Cost"
+                  value={bulkCustomCost.monthlyCost}
+                  onChange={handleChange}
+                />
+              </FormControl>
+            </Grid>
+            {bulkCustomCost.provider && (
+              <Grid item xs={12} md={12}>
+                <FormControl fullWidth sx={{ m: 1 }}>
+                  <Alert severity="info">{generateRecords().length} record(s) will be inserted.</Alert>
+                </FormControl>
+                <TableContainer component={Paper}>
+                  <Table>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Provider</TableCell>
+                        <TableCell>Account</TableCell>
+                        <TableCell>Service</TableCell>
+                        <TableCell>Category</TableCell>
+                        <TableCell align="right">Usage Month</TableCell>
+                        <TableCell align="right">Cost</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {generateRecords().map(row => (
+                        <TableRow key={row.usage_month} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
+                          <TableCell component="th" scope="row">
+                            {row.provider}
+                          </TableCell>
+                          <TableCell>{row.account}</TableCell>
+                          <TableCell>{row.service}</TableCell>
+                          <TableCell>{row.category}</TableCell>
+                          <TableCell align="right">{row.usage_month}</TableCell>
+                          <TableCell align="right">{row.cost}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Grid>
+            )}
+          </Grid>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="contained" type="submit" disabled={submittingForm}>
+            Insert
+          </Button>
+          <Button onClick={handleClose}>Close</Button>
+        </DialogActions>
+      </Dialog>
+    </React.Fragment>
+  );
+};

--- a/plugins/infrawallet/src/components/CustomCostsComponent/CustomCostsComponent.tsx
+++ b/plugins/infrawallet/src/components/CustomCostsComponent/CustomCostsComponent.tsx
@@ -1,0 +1,427 @@
+import { Content, Header, Page } from '@backstage/core-components';
+import { alertApiRef, configApiRef, useApi } from '@backstage/core-plugin-api';
+import { Chip, Grid } from '@material-ui/core';
+import AddIcon from '@mui/icons-material/Add';
+import CancelIcon from '@mui/icons-material/Cancel';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import SaveIcon from '@mui/icons-material/Save';
+import Autocomplete from '@mui/material/Autocomplete';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Tooltip, { TooltipProps, tooltipClasses } from '@mui/material/Tooltip';
+import { styled } from '@mui/material/styles';
+import moment from 'moment';
+import React, { FC, useCallback, useEffect, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { infraWalletApiRef } from '../../api/InfraWalletApi';
+import { CustomCost } from '../../api/types';
+import { BulkInsertButton } from './BulkInsertButton';
+
+import {
+  DataGrid,
+  GridActionsCellItem,
+  GridColDef,
+  GridEditInputCell,
+  GridEventListener,
+  GridPreProcessEditCellProps,
+  GridRenderEditCellParams,
+  GridRowEditStopReasons,
+  GridRowId,
+  GridRowModel,
+  GridRowModes,
+  GridRowModesModel,
+  GridRowsProp,
+  GridSlots,
+  GridToolbar,
+  GridToolbarContainer,
+  GridToolbarFilterButton,
+  ValueOptions,
+} from '@mui/x-data-grid';
+
+const StyledTooltip = styled(({ className, ...props }: TooltipProps) => (
+  <Tooltip {...props} classes={{ popper: className }} />
+))(({ theme }) => ({
+  [`& .${tooltipClasses.tooltip}`]: {
+    backgroundColor: theme.palette.error.main,
+    color: theme.palette.error.contrastText,
+  },
+}));
+
+export const CustomCostsComponent: FC = () => {
+  const configApi = useApi(configApiRef);
+  const alertApi = useApi(alertApiRef);
+  const infraWalletApi = useApi(infraWalletApiRef);
+  const [rows, setRows] = useState<GridRowsProp>([]);
+  const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
+
+  const readOnly = configApi.getOptionalBoolean('infraWallet.settings.readOnly') ?? false;
+
+  const handleRowEditStop: GridEventListener<'rowEditStop'> = (params, event) => {
+    if (params.reason === GridRowEditStopReasons.rowFocusOut) {
+      event.defaultMuiPrevented = true;
+    }
+  };
+
+  const handleCloneClick = (row: any) => () => {
+    const uuid = uuidv4();
+    setRows(oldRows => [
+      {
+        id: uuid,
+        provider: row.provider,
+        account: row.account,
+        service: row.service,
+        category: row.category,
+        amortization_mode: row.amortization_mode,
+        usage_month: parseInt(moment(new Date()).format('YYYYMM'), 10),
+        cost: 0,
+        tags: {},
+        isNew: true,
+      },
+      ...oldRows,
+    ]);
+    setRowModesModel(oldModel => ({
+      ...oldModel,
+      [uuid]: { mode: GridRowModes.Edit, fieldToFocus: 'provider' },
+    }));
+  };
+
+  const handleEditClick = (id: GridRowId) => () => {
+    setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.Edit } });
+  };
+
+  const handleSaveClick = (id: GridRowId) => () => {
+    setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.View } });
+  };
+
+  const handleDeleteClick = (row: GridRowModel) => () => {
+    const { isNew, ...customCost } = row;
+    infraWalletApi
+      .deleteCustomCost(customCost as CustomCost)
+      .then((response: any) => {
+        if (response.status === 200) {
+          setRows(rows.filter(r => r.id !== row.id));
+        } else {
+          alertApi.post({ message: 'Failed to delete the custom cost', severity: 'error' });
+        }
+      })
+      .catch(e => alertApi.post({ message: `${e.message}`, severity: 'error' }));
+  };
+
+  const handleCancelClick = (id: GridRowId) => () => {
+    setRowModesModel({
+      ...rowModesModel,
+      [id]: { mode: GridRowModes.View, ignoreModifications: true },
+    });
+
+    const editedRow = rows.find(row => row.id === id);
+    if (editedRow!.isNew) {
+      setRows(rows.filter(row => row.id !== id));
+    }
+  };
+
+  const processRowUpdate = (newRow: GridRowModel) => {
+    const updatedRow = { ...newRow, isNew: false };
+    const { isNew, ...customCost } = updatedRow;
+
+    infraWalletApi
+      .updateCustomCost(customCost as CustomCost)
+      .then((response: any) => {
+        if (response.status === 200) {
+          setRows(rows.map(row => (row.id === newRow.id ? updatedRow : row)));
+        } else {
+          alertApi.post({ message: 'Failed to update the custom cost', severity: 'error' });
+        }
+      })
+      .catch(e => alertApi.post({ message: `${e.message}`, severity: 'error' }));
+
+    return updatedRow;
+  };
+
+  const handleRowModesModelChange = (newRowModesModel: GridRowModesModel) => {
+    setRowModesModel(newRowModesModel);
+  };
+
+  const columns: GridColDef[] = [
+    {
+      field: 'provider',
+      headerName: 'Provider',
+      width: 220,
+      editable: !readOnly,
+      display: 'flex',
+    },
+    {
+      field: 'account',
+      headerName: 'Account',
+      width: 180,
+      editable: !readOnly,
+    },
+    {
+      field: 'service',
+      headerName: 'Service',
+      width: 220,
+      editable: !readOnly,
+    },
+    {
+      field: 'category',
+      headerName: 'Category',
+      width: 200,
+      editable: !readOnly,
+      renderEditCell: (params: GridRenderEditCellParams) => (
+        <Autocomplete
+          fullWidth
+          freeSolo
+          options={[
+            'Uncategorized',
+            'Analytics',
+            'Application Integration',
+            'Cloud Financial Management',
+            'Compute',
+            'Containers',
+            'Database',
+            'Developer Tools',
+            'Front-End Web & Mobile',
+            'Internet of Things',
+            'Management & Governance',
+            'Migration',
+            'Networking',
+            'Security, Identity, & Compliance',
+            'Storage',
+          ]}
+          onChange={(_, value) => params.api.setEditCellValue({ id: params.id, field: params.field, value: value })}
+          renderInput={p => (
+            <TextField
+              {...p}
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                params.api.setEditCellValue({ id: params.id, field: params.field, value: event.target.value })
+              }
+            />
+          )}
+        />
+      ),
+    },
+    {
+      field: 'amortization_mode',
+      headerName: 'Amortization Mode',
+      width: 150,
+      editable: !readOnly,
+      type: 'singleSelect',
+      valueOptions: (_params: any) => {
+        const options: ValueOptions[] = [
+          { value: 'average', label: 'Average' },
+          { value: 'start_day', label: 'Start day of the month' },
+          { value: 'end_day', label: 'End day of the month' },
+        ];
+        return options;
+      },
+    },
+    {
+      field: 'usage_month',
+      headerName: 'Usage Month',
+      width: 150,
+      editable: !readOnly,
+    },
+    {
+      field: 'cost',
+      headerName: 'Cost',
+      width: 100,
+      editable: !readOnly,
+      type: 'number',
+    },
+    {
+      field: 'tags',
+      headerName: 'Tags (in JSON)',
+      flex: 1,
+      editable: !readOnly,
+      sortable: false,
+      renderCell: (params: { row: { tags?: Record<string, string> } }) => {
+        const tags = params.row.tags || {};
+        return (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+            {Object.entries(tags).map(([key, value]) => (
+              <Chip key={key} label={`${key}:${value}`} size="small" />
+            ))}
+          </div>
+        );
+      },
+      valueGetter: (params: any): string => {
+        return JSON.stringify(params);
+      },
+      valueSetter: (value: string, row: any) => {
+        let tags = null;
+        if (value) {
+          try {
+            tags = JSON.parse(value);
+          } catch (e) {
+            // Invalid JSON
+          }
+        }
+        return { ...row, tags };
+      },
+      preProcessEditCellProps: (params: GridPreProcessEditCellProps) => {
+        let errorMsg = null;
+        if (params.props.value) {
+          try {
+            JSON.parse(params.props.value);
+          } catch (e) {
+            errorMsg = 'Invalid JSON format. Please use key-value pairs in JSON format, e.g. {"key1":"value1"}';
+          }
+        }
+        return { ...params.props, error: errorMsg };
+      },
+      renderEditCell: (props: GridRenderEditCellParams) => {
+        const { error } = props;
+
+        return (
+          <StyledTooltip open={!!error} title={error}>
+            <GridEditInputCell {...props} />
+          </StyledTooltip>
+        );
+      },
+    },
+  ];
+
+  if (!readOnly) {
+    columns.push({
+      field: 'actions',
+      type: 'actions',
+      headerName: 'Actions',
+      width: 100,
+      cellClassName: 'actions',
+      getActions: ({ id, row }) => {
+        const isInEditMode = rowModesModel[id]?.mode === GridRowModes.Edit;
+
+        if (isInEditMode) {
+          return [
+            <GridActionsCellItem
+              icon={<SaveIcon />}
+              label="Save"
+              sx={{
+                color: 'primary.main',
+              }}
+              onClick={handleSaveClick(id)}
+            />,
+            <GridActionsCellItem
+              icon={<CancelIcon />}
+              label="Cancel"
+              className="textPrimary"
+              onClick={handleCancelClick(id)}
+              color="inherit"
+            />,
+          ];
+        }
+
+        return [
+          <GridActionsCellItem
+            icon={<ContentCopyIcon />}
+            label="Clone"
+            className="textPrimary"
+            onClick={handleCloneClick(row)}
+            color="inherit"
+          />,
+          <GridActionsCellItem
+            icon={<EditIcon />}
+            label="Edit"
+            className="textPrimary"
+            onClick={handleEditClick(id)}
+            color="inherit"
+          />,
+          <GridActionsCellItem icon={<DeleteIcon />} label="Delete" onClick={handleDeleteClick(row)} color="inherit" />,
+        ];
+      },
+    });
+  }
+
+  const getCustomCosts = useCallback(async () => {
+    await infraWalletApi
+      .getCustomCosts()
+      .then(customCostsResponse => {
+        if (customCostsResponse.data && customCostsResponse.status === 200) {
+          setRows(customCostsResponse.data);
+        }
+      })
+      .catch(e => alertApi.post({ message: `${e.message}`, severity: 'error' }));
+  }, [infraWalletApi, alertApi]);
+
+  function EditToolbar() {
+    const handleClick = () => {
+      const id = uuidv4();
+      setRows(oldRows => [
+        {
+          id: id,
+          provider: '',
+          account: '',
+          service: '',
+          category: '',
+          amortization_mode: 'average',
+          usage_month: parseInt(moment(new Date()).format('YYYYMM'), 10),
+          cost: 0,
+          tags: {},
+          isNew: true,
+        },
+        ...oldRows,
+      ]);
+      setRowModesModel(oldModel => ({
+        ...oldModel,
+        [id]: { mode: GridRowModes.Edit, fieldToFocus: 'provider' },
+      }));
+    };
+
+    return (
+      <GridToolbarContainer>
+        <Button color="primary" startIcon={<AddIcon />} onClick={handleClick}>
+          Add custom cost
+        </Button>
+        <BulkInsertButton reloadFunction={getCustomCosts} />
+        <GridToolbarFilterButton />
+      </GridToolbarContainer>
+    );
+  }
+  useEffect(() => {
+    getCustomCosts();
+  }, [getCustomCosts]);
+
+  return (
+    <Page themeId="tool">
+      <Header title="Custom Costs Management" />
+      <Content>
+        <Grid container spacing={3}>
+          <Grid item xs={12}>
+            <Box
+              sx={{
+                height: 700,
+                width: '100%',
+                '& .actions': {
+                  color: 'text.secondary',
+                },
+                '& .textPrimary': {
+                  color: 'text.primary',
+                },
+              }}
+            >
+              <DataGrid
+                rows={rows}
+                columns={columns}
+                editMode="row"
+                rowModesModel={rowModesModel}
+                onRowModesModelChange={handleRowModesModelChange}
+                onRowEditStop={handleRowEditStop}
+                processRowUpdate={processRowUpdate}
+                initialState={{
+                  sorting: {
+                    sortModel: [{ field: 'usage_month', sort: 'desc' }],
+                  },
+                }}
+                slots={{
+                  toolbar: readOnly ? GridToolbar : (EditToolbar as GridSlots['toolbar']),
+                }}
+              />
+            </Box>
+          </Grid>
+        </Grid>
+      </Content>
+    </Page>
+  );
+};

--- a/plugins/infrawallet/src/components/CustomCostsComponent/index.ts
+++ b/plugins/infrawallet/src/components/CustomCostsComponent/index.ts
@@ -1,0 +1,1 @@
+export { CustomCostsComponent } from './CustomCostsComponent';

--- a/plugins/infrawallet/src/components/Router.tsx
+++ b/plugins/infrawallet/src/components/Router.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 
-import { SettingsComponent } from './SettingsComponent';
+import { CustomCostsComponent } from './CustomCostsComponent';
 import { ReportsComponent, ReportsComponentProps } from './ReportsComponent';
+import { SettingsComponent } from './SettingsComponent';
 
 export const Router = (props: ReportsComponentProps) => {
   return (
     <Routes>
       <Route path="/" element={<ReportsComponent {...props} />} />
+      <Route path="/custom_costs" element={<CustomCostsComponent />} />
       <Route path="/:name" element={<ReportsComponent {...props} />} />
       <Route path="/:name/settings" element={<SettingsComponent />} />
     </Routes>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4662,6 +4662,7 @@ __metadata:
     "@types/supertest": ^2.0.8
     express: ^4.17.1
     express-promise-router: ^4.1.0
+    knex: ^3.1.0
     lodash: ^4.17.21
     moment: 2.29.4
     msw: ^1.0.0
@@ -20064,7 +20065,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"knex@npm:3, knex@npm:^3.0.0":
+"knex@npm:3, knex@npm:^3.0.0, knex@npm:^3.1.0":
   version: 3.1.0
   resolution: "knex@npm:3.1.0"
   dependencies:


### PR DESCRIPTION
The custom cost management UI is available via `/infrawallet/custom_costs`. To enable custom costs support, the following configuration needs to be added:

```yaml
backend:
  infraWallet:
    integrations:
      custom:
        - name: <arbitrary_string>
```

Some screenshots:

![image](https://github.com/user-attachments/assets/a777cf56-5fbc-4623-94f8-6619799d320d)

![image](https://github.com/user-attachments/assets/a1cf65e3-a4ee-484d-ac6a-5981eb312b17)

![image](https://github.com/user-attachments/assets/170c9541-dad6-4b44-8db1-69f5eea9dd42)
