### PR TITLE
Fix confluent deleted environment

### DIFF
--- a/plugins/infrawallet-backend/src/cost-clients/ConfluentClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/ConfluentClient.ts
@@ -94,7 +94,6 @@ export class ConfluentClient extends InfraWalletClient {
           .map((item: any) => item.resource?.environment?.id)
           .filter((id: any) => id !== undefined))];
 
-        this.logger.info(`Confluent Envs: ${envIds}`);
         const envNamePromises = envIds.map(envId => this.fetchEnvDisplayName(client, envId));
         const envNames = await Promise.all(envNamePromises);
 

--- a/plugins/infrawallet-backend/src/cost-clients/ConfluentClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/ConfluentClient.ts
@@ -41,7 +41,8 @@ export class ConfluentClient extends InfraWalletClient {
     });
 
     if (!response.ok) {
-      throw new Error(`Failed to fetch environment name for ${envId}: ${response.statusText}`);
+      this.logger.warn(`Failed to fetch environment name for ${envId}: ${response.statusText}`);
+      return envId
     }
 
     const jsonResponse = await response.json();
@@ -89,8 +90,11 @@ export class ConfluentClient extends InfraWalletClient {
 
         const jsonResponse: { data: any[] } = await response.json();
 
-        const envIds = [...new Set(jsonResponse.data.map((item: any) => item.resource.environment.id))];
+        const envIds = [...new Set(jsonResponse.data
+          .map((item: any) => item.resource?.environment?.id)
+          .filter((id: any) => id !== undefined))];
 
+        this.logger.info(`Confluent Envs: ${envIds}`);
         const envNamePromises = envIds.map(envId => this.fetchEnvDisplayName(client, envId));
         const envNames = await Promise.all(envNamePromises);
 
@@ -99,7 +103,9 @@ export class ConfluentClient extends InfraWalletClient {
           envIdToName[envId] = envNames[index];
         });
 
-        const dataWithEnvNames = jsonResponse.data.map((item: any) => {
+        const dataWithEnvNames = jsonResponse.data
+        .filter((item: any) => item.resource?.environment?.id)
+        .map((item: any) => {
           const envId = item.resource.environment.id;
           return {
             ...item,

--- a/plugins/infrawallet-backend/src/cost-clients/ConfluentClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/ConfluentClient.ts
@@ -42,7 +42,7 @@ export class ConfluentClient extends InfraWalletClient {
 
     if (!response.ok) {
       this.logger.warn(`Failed to fetch environment name for ${envId}: ${response.statusText}`);
-      return envId
+      return envId;
     }
 
     const jsonResponse = await response.json();
@@ -90,9 +90,11 @@ export class ConfluentClient extends InfraWalletClient {
 
         const jsonResponse: { data: any[] } = await response.json();
 
-        const envIds = [...new Set(jsonResponse.data
-          .map((item: any) => item.resource?.environment?.id)
-          .filter((id: any) => id !== undefined))];
+        const envIds = [
+          ...new Set(
+            jsonResponse.data.map((item: any) => item.resource?.environment?.id).filter((id: any) => id !== undefined),
+          ),
+        ];
 
         const envNamePromises = envIds.map(envId => this.fetchEnvDisplayName(client, envId));
         const envNames = await Promise.all(envNamePromises);
@@ -103,14 +105,14 @@ export class ConfluentClient extends InfraWalletClient {
         });
 
         const dataWithEnvNames = jsonResponse.data
-        .filter((item: any) => item.resource?.environment?.id)
-        .map((item: any) => {
-          const envId = item.resource.environment.id;
-          return {
-            ...item,
-            envDisplayName: envIdToName[envId] || 'Unknown',
-          };
-        });
+          .filter((item: any) => item.resource?.environment?.id)
+          .map((item: any) => {
+            const envId = item.resource.environment.id;
+            return {
+              ...item,
+              envDisplayName: envIdToName[envId] || 'Unknown',
+            };
+          });
 
         aggregatedData = aggregatedData.concat(dataWithEnvNames);
 


### PR DESCRIPTION
This PR ensures that:

- Costs associated with deleted environments are displayed.
- Costs without a defined environment are ignored. Without this fix, attempting to locate costs in categories like "Support" would result in the process being interrupted by an exception. This PR handles such cases gracefully by ignoring those undefined costs.





