### PR TITLE
feat(mui4 compat typography): 

### DIFF
--- a/plugins/infrawallet/src/components/FiltersComponent/FiltersComponent.tsx
+++ b/plugins/infrawallet/src/components/FiltersComponent/FiltersComponent.tsx
@@ -29,7 +29,7 @@ const HtmlTooltip = withStyles((theme: Theme) => ({
     backgroundColor: '#f5f5f9',
     color: 'rgba(0, 0, 0, 0.87)',
     maxWidth: 400,
-    fontSize: theme.typography.pxToRem(14),
+    fontSize: typeof theme.typography?.pxToRem === 'function' ? theme.typography.pxToRem(14) : '14px',
     border: '1px solid #dadde9',
   },
 }))(Tooltip);


### PR DESCRIPTION
mismatch in typography settings between mui4 and 5 when using a custom theme via unified theme provider requires a fallback for the typography as it will be unable to read it from the unified theme provider.

While this is not an actual bug with any of the code in infrawallet itself near as I can tell, we can guard against this sort of footgun in the mui4/ui5 compatibility layer of the unified theme provider.

https://github.com/backstage/backstage/issues/26754
sorta tracked by this issue in the main backstage repo.