### PR TITLE
enhancement(gcp creds search): 

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -140,11 +140,26 @@ backend:
     integrations:
       gcp:
         - name: <unique_name_of_this_integration>
-          keyFilePath: <path_to_your_json_key_file> # if you run it in a k8s pod, you may need to create a secret and mount it to the pod
+          keyFilePath: <path_to_your_json_key_file> # Supports environment variables, tilde expansion
           projectId: <GCP_project_that_your_big_query_dataset_belongs_to>
           datasetId: <big_query_dataset_id>
           tableId: <big_query_table_id>
 ```
+
+The `keyFilePath` supports multiple formats:
+
+- Absolute paths: `/path/to/key.json`
+- Relative paths: `./path/to/key.json`
+- Home directory expansion: `~/path/to/key.json`
+- Environment variables: `$HOME/.config/gcloud/key.json` or `${HOME}/.config/gcloud/key.json`
+
+InfraWallet will also check for the standard `GOOGLE_APPLICATION_CREDENTIALS` environment variable. You have these authentication options in order of precedence:
+
+1. Explicitly configured `keyFilePath` in app-config.yaml (highest priority)
+2. `GOOGLE_APPLICATION_CREDENTIALS` environment variable
+3. Application Default Credentials from standard locations
+
+If none of these options are successful, you'll see appropriate error messages in the logs to help troubleshoot the issue.
 
 ### Confluent Cloud Integration
 
@@ -241,7 +256,7 @@ Currently, only AWS and Datadog integrations support filters.
 ## Custom Costs
 
 If there is no integration available for some cloud costs, you can add them manually using the Custom Costs UI in InfraWallet. The table on this page displays all saved custom
-costs within InfraWallet’s database.
+costs within InfraWallet's database.
 
 Currently, custom costs are only available at the monthly level. When viewing costs with `daily` granularity, monthly custom costs can be transformed into daily costs using the following amortization modes:
 

--- a/plugins/infrawallet-backend/src/cost-clients/GCPClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/GCPClient.ts
@@ -174,8 +174,8 @@ export class GCPClient extends InfraWalletClient {
             provider: this.provider,
             providerType: PROVIDER_TYPE.INTEGRATION,
             reports: {},
-            ...{ project: row.project },
-            ...tagKeyValues,
+            ...{ project: row.project }, // TODO: how should we handle the project field? for now, we add project name as a field in the report
+            ...tagKeyValues, // note that if there is a tag `project:foo` in config, it overrides the project field set above
           };
         }
 

--- a/plugins/infrawallet-backend/src/cost-clients/GCPClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/GCPClient.ts
@@ -1,7 +1,10 @@
+import { BigQuery } from '@google-cloud/bigquery';
 import { CacheService, DatabaseService, LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
-import { BigQuery } from '@google-cloud/bigquery';
 import { reduce } from 'lodash';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
 import { CategoryMappingService } from '../service/CategoryMappingService';
 import { CLOUD_PROVIDER, PROVIDER_TYPE } from '../service/consts';
 import { CostQuery, Report } from '../service/types';
@@ -26,18 +29,83 @@ export class GCPClient extends InfraWalletClient {
     return `${this.provider}/${convertedName}`;
   }
 
+  /**
+   * Resolves a file path, handling POSIX-style paths with environment variables and tilde expansion.
+   * Supports:
+   * - Relative paths: "./path/to/file.json"
+   * - Absolute paths: "/path/to/file.json"
+   * - Home directory: "~/path/to/file.json"
+   * - Environment variables: "$HOME/path/to/file.json", "${HOME}/path/to/file.json"
+   *
+   * @param filePath The path to resolve
+   * @returns The resolved path, or null if the path cannot be resolved
+   */
+  private resolvePath(filePath: string): string | null {
+    try {
+      let resolvedPath = filePath.replace(/\$([A-Za-z0-9_]+)|\$\{([A-Za-z0-9_]+)\}/g, (match, p1, p2) => {
+        const varName = p1 || p2;
+        const value = process.env[varName];
+        if (!value) {
+          this.logger.warn(`Environment variable ${varName} not found when resolving path: ${filePath}`);
+          return match;
+        }
+        return value;
+      });
+
+      if (resolvedPath.startsWith('~')) {
+        const homeDirectory = homedir();
+        resolvedPath = join(homeDirectory, resolvedPath.substring(1));
+      }
+
+      if (!existsSync(resolvedPath)) {
+        this.logger.warn(`File does not exist at resolved path: ${resolvedPath}`);
+        return null;
+      }
+
+      return resolvedPath;
+    } catch (error) {
+      this.logger.error(`Error resolving path ${filePath}: ${error.message}`);
+      return null;
+    }
+  }
+
   protected async initCloudClient(subAccountConfig: Config): Promise<any> {
-    const keyFilePath = subAccountConfig.getString('keyFilePath');
     const projectId = subAccountConfig.getString('projectId');
-    // Configure a JWT auth client
-    const options = {
-      keyFilename: keyFilePath,
-      projectId: projectId,
-    };
+    const options: any = { projectId };
 
-    // Initialize the BigQuery API
+    const adcEnvPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    if (adcEnvPath) {
+      if (existsSync(adcEnvPath)) {
+        this.logger.info(`Using GCP credentials from GOOGLE_APPLICATION_CREDENTIALS env var: ${adcEnvPath}`);
+      } else {
+        this.logger.warn(`GOOGLE_APPLICATION_CREDENTIALS points to non-existent file: ${adcEnvPath}`);
+      }
+    }
+
+    const keyFilePath = subAccountConfig.getOptionalString('keyFilePath');
+
+    if (keyFilePath) {
+      const resolvedPath = this.resolvePath(keyFilePath);
+
+      if (resolvedPath) {
+        this.logger.info(`Using GCP credentials file at: ${resolvedPath}`);
+        options.keyFilename = resolvedPath;
+
+        if (adcEnvPath) {
+          this.logger.info('Overriding GOOGLE_APPLICATION_CREDENTIALS with keyFilePath from config');
+        }
+      } else {
+        this.logger.info(
+          `GCP credentials file not found at ${keyFilePath}, falling back to application default credentials`,
+        );
+      }
+    } else if (!adcEnvPath) {
+      this.logger.info(
+        'No keyFilePath or GOOGLE_APPLICATION_CREDENTIALS specified, using application default credentials',
+      );
+    }
+
     const bigqueryClient = new BigQuery(options);
-
     return bigqueryClient;
   }
 
@@ -66,16 +134,14 @@ export class GCPClient extends InfraWalletClient {
         ORDER BY
           project, period, total_cost DESC`;
 
-      // Run the query as a job
       const [job] = await client.createQueryJob({
         query: sql,
       });
 
-      // Wait for the query to finish
       const [rows] = await job.getQueryResults();
-
       return rows;
     } catch (err) {
+      this.logger.error(`Error executing BigQuery: ${err.message}`);
       throw new Error(err.message);
     }
   }
@@ -108,13 +174,12 @@ export class GCPClient extends InfraWalletClient {
             provider: this.provider,
             providerType: PROVIDER_TYPE.INTEGRATION,
             reports: {},
-            ...{ project: row.project }, // TODO: how should we handle the project field? for now, we add project name as a field in the report
-            ...tagKeyValues, // note that if there is a tag `project:foo` in config, it overrides the project field set above
+            ...{ project: row.project },
+            ...tagKeyValues,
           };
         }
 
         acc[keyName].reports[period] = parseFloat(row.total_cost);
-
         return acc;
       },
       {},


### PR DESCRIPTION
the current credentials finder is a bit inflexible and expects a creds file in a likely non standard location the root of the backend or the final bundle, this change allows setting various path locations on the filesystem to where an existing credential maybe and defaults to the GOOGLE_APPLICATION_CREDENTIALS/ADC standard if a keypath is not provided

https://cloud.google.com/docs/authentication/application-default-credentials

there is an element of opinion in how to structure this, so let me know what you think i am happy to adjust but following the ADC/ENV definition makes this alot easier to use in existing projects.