### PR TITLE
#139 optional config to hide unwanted tabs of a wallet

### DIFF
--- a/plugins/infrawallet/config.d.ts
+++ b/plugins/infrawallet/config.d.ts
@@ -7,6 +7,7 @@ export interface Config {
       defaultGroupBy?: string; // if not set, `none` will be used
       defaultShowLastXMonths?: number; // if not set, 3 will be used
       readOnly?: boolean; // false by default
+      hideWalletTabs?: string[]; // tabs that stay hidden to users, valid values (case insensitive) are: Budgets, Custom Costs, Business Metrics
     };
   };
 }

--- a/plugins/infrawallet/src/components/ReportsComponent/ReportsComponent.tsx
+++ b/plugins/infrawallet/src/components/ReportsComponent/ReportsComponent.tsx
@@ -65,7 +65,7 @@ const checkIfFiltersActivated = (filters: Filters): boolean => {
   return activated;
 };
 
-const tabs = [{ label: 'Overview' }, { label: 'Budgets' }, { label: 'Custom Costs' }, { label: 'Business Metrics' }];
+const allTabNames = ['Overview', 'Budgets', 'Custom Costs', 'Business Metrics'];
 
 export const ReportsComponent = (props: ReportsComponentProps) => {
   const { title, subTitle } = props;
@@ -73,6 +73,9 @@ export const ReportsComponent = (props: ReportsComponentProps) => {
   const params = useParams();
 
   let defaultGroupBy = configApi.getOptionalString('infraWallet.settings.defaultGroupBy') ?? 'none';
+  const hideWalletTabs = configApi.getOptionalStringArray('infraWallet.settings.hideWalletTabs') ?? [];
+  const hideWalletTabsLowerCase = hideWalletTabs.map(tab => tab.toLowerCase());
+  const tabsToShow = allTabNames.filter(tab => !hideWalletTabsLowerCase.includes(tab.toLowerCase()));
   // "name" is renamed to "account", make it backward compatibility
   if (defaultGroupBy === 'name') {
     defaultGroupBy = 'account';
@@ -153,14 +156,38 @@ export const ReportsComponent = (props: ReportsComponentProps) => {
     fetchMetricsCallback();
   }, [fetchCostReportsCallback, fetchMetricsCallback]);
 
+  // provide a way for users to access these tabs, if they are configfured to be hidden
+  useEffect(() => {
+    if (params.selectedView) {
+      switch (params.selectedView) {
+        case 'budgets': {
+          setSelectedView('Budgets');
+          break;
+        }
+        case 'custom_costs': {
+          setSelectedView('Custom Costs');
+          break;
+        }
+        case 'business_metrics': {
+          setSelectedView('Business Metrics');
+          break;
+        }
+        default: {
+          setSelectedView('Overview');
+          break;
+        }
+      }
+    }
+  }, [params]);
+
   return (
     <Page themeId="tool">
       <Header title={title ?? 'InfraWallet'} subtitle={subTitle ?? ''} />
       <HeaderTabs
-        tabs={tabs.map(tab => {
-          return { id: tab.label, label: tab.label };
+        tabs={tabsToShow.map(tab => {
+          return { id: tab, label: tab };
         })}
-        onChange={index => setSelectedView(tabs[index].label)}
+        onChange={index => setSelectedView(tabsToShow[index])}
       />
       <Content>
         <Grid container spacing={3}>

--- a/plugins/infrawallet/src/components/Router.tsx
+++ b/plugins/infrawallet/src/components/Router.tsx
@@ -7,6 +7,7 @@ export const Router = (props: ReportsComponentProps) => {
     <Routes>
       <Route path="/" element={<ReportsComponent {...props} />} />
       <Route path="/:name" element={<ReportsComponent {...props} />} />
+      <Route path="/:name/:selectedView" element={<ReportsComponent {...props} />} />
     </Routes>
   );
 };


### PR DESCRIPTION
This PR implements optional frontend config for hiding unwanted tabs, as requested by #139 

The config is defined in `plugins/infrawallet/config.d.ts`:

```diff
export interface Config {
  infraWallet: {
    /**
     * @deepVisibility frontend
     */
    settings: {
      defaultGroupBy?: string; // if not set, `none` will be used
      defaultShowLastXMonths?: number; // if not set, 3 will be used
      readOnly?: boolean; // false by default
+     hideWalletTabs?: string[]; // tabs that stay hidden to users, valid values (case insensitive) are: Budgets, Custom Costs, Business Metrics
    };
  };
}

```

To hide a tab, for example, `Budgets`, user needs to add the following config into the yaml file:
```yaml
infraWallet:
  settings:
    hideWalletTabs:
      - Budgets
```

Note that this config just makes the tabs invisible for users but it does not block the features. If there is a need to access these pages while the tabs are hidden, users can use the following links:

- Budgets: `<app_domain>/infrawallet/default/budgets`
- Custom Costs: `<app_domain>/infrawallet/default/custom_costs`
- Business Metrics: `<app_domain>/infrawallet/default/business_metrics`