### PR TITLE
Add an ExtensionPoint for EntityReports

### DIFF
--- a/docs/getting-started/extensions.md
+++ b/docs/getting-started/extensions.md
@@ -4,7 +4,7 @@ The plugin offers extension points that allow parts of the report generation to 
 
 ## InfrawalletReportFilterExtensionPoint
 
-This extension point allows to augement or append to the provided filters through custom information.
+This extension point allows to augment or append to the provided filters through custom information.
 
 For this the following interface can be used
 

--- a/docs/getting-started/extensions.md
+++ b/docs/getting-started/extensions.md
@@ -1,0 +1,40 @@
+# Extensions
+
+The plugin offers extension points that allow parts of the report generation to be customised.
+
+## InfrawalletReportFilterExtensionPoint
+
+This extension point allows to augement or append to the provided filters through custom information.
+
+For this the following interface can be used
+
+```ts
+export interface InfrawalletFilterExtension {
+  augmentFilters(parameters: ReportParameters): ReportParameters;
+}
+```
+
+The type `ReportParameters`
+
+```ts
+export type ReportParameters = {
+  filters: string;
+  tags: Tag[];
+  groups: string;
+  granularityString: string;
+  startTime: string;
+  endTime: string;
+  entityNamespace?: string;
+  entityName?: string;
+};
+```
+
+The `filters` string has the following format:
+
+```ts
+(key1:value,key2:value,...,keyN:value)
+```
+
+where value is either a single value or an array with the following structure `(value1|value2|...|valueN)`.
+
+The following keys are defined through the annotations of the `EntityInfraWalletCard` listed in [the documentation](https://opensource.electrolux.one/infrawallet/getting-started/installation/#integrate-with-backstage-catalog-optional). Other keys can be passed through if your targeted integration supports it.

--- a/docs/getting-started/extensions.md
+++ b/docs/getting-started/extensions.md
@@ -38,3 +38,51 @@ The `filters` string has the following format:
 where value is either a single value or an array with the following structure `(value1|value2|...|valueN)`.
 
 The following keys are defined through the annotations of the `EntityInfraWalletCard` listed in [the documentation](https://opensource.electrolux.one/infrawallet/getting-started/installation/#integrate-with-backstage-catalog-optional). Other keys can be passed through if your targeted integration supports it.
+
+Below an example implementation of the extension point.
+
+```ts
+class InfraWalletFilter implements InfrawalletFilterExtension {
+  readonly logger: LoggerService;
+  readonly catalogApi: CatalogApi;
+  readonly myProvider = 'theProvider';
+
+  constructor(logger: LoggerService, catalogApi: CatalogApi) {
+    this.logger = logger;
+    this.catalogApi = catalogApi;
+  }
+
+  augmentFilters(filters: ReportParameters): ReportParameters {
+    this.catalogApi.getEntityByRef(`${filters.entityNamespace}/${filters.entityName}`).then(entity => {
+      if (entity) {
+        const entityTags: Tag[] = [];
+
+        if (entity.metadata.labels) {
+          for (const [key, value] of Object.entries(entity.metadata.labels)) {
+            entityTags.push({ key, value, provider: this.myProvider });
+          }
+        }
+        filters.tags.push(...entityTags);
+      }
+    });
+    return filters;
+  }
+}
+
+export const infrawalletModuleFilterextension = createBackendModule({
+  pluginId: 'infrawallet',
+  moduleId: 'filterextension',
+  register(reg) {
+    reg.registerInit({
+      deps: {
+        logger: coreServices.logger,
+        infraWalletExtension: infrawalletReportFilterExtensionPoint,
+        catalogApi: catalogServiceRef,
+      },
+      async init({ logger, infraWalletExtension, catalogApi }) {
+        infraWalletExtension.addReportFilter(new InfraWalletFilter(logger, catalogApi));
+      },
+    });
+  },
+});
+```

--- a/docs/getting-started/extensions.md
+++ b/docs/getting-started/extensions.md
@@ -61,7 +61,6 @@ class InfraWalletFilter implements InfrawalletFilterExtension {
   ) {}
 
   async augmentFilters(filters: ReportParameters): Promise<ReportParameters> {
-
     if (filters.entityName === undefined || filters.entityNamespace === undefined) {
       return filters;
     }

--- a/docs/getting-started/extensions.md
+++ b/docs/getting-started/extensions.md
@@ -61,6 +61,11 @@ class InfraWalletFilter implements InfrawalletFilterExtension {
   ) {}
 
   async augmentFilters(filters: ReportParameters): Promise<ReportParameters> {
+
+    if (filters.entityName === undefined || filters.entityNamespace === undefined) {
+      return filters;
+    }
+
     const entity = await this.catalogApi.getEntityByRef(`${filters.entityNamespace}/${filters.entityName}`, {
       credentials: await this.auth.getOwnServiceCredentials(),
     });

--- a/plugins/infrawallet-backend/package.json
+++ b/plugins/infrawallet-backend/package.json
@@ -47,6 +47,7 @@
     "@azure/identity": "4.5.0",
     "@backstage/backend-defaults": "^0.11.0",
     "@backstage/backend-plugin-api": "^1.4.0",
+    "@backstage/catalog-model": "^1.7.5",
     "@backstage/config": "^1.3.2",
     "@backstage/types": "^1.2.1",
     "@datadog/datadog-api-client": "^1.29.0",

--- a/plugins/infrawallet-backend/src/extension.ts
+++ b/plugins/infrawallet-backend/src/extension.ts
@@ -1,18 +1,14 @@
 import { createExtensionPoint } from '@backstage/backend-plugin-api';
-import { CloudProviderError, Report, ReportParameters } from './service/types';
+import { ReportParameters } from './service/types';
 
-export interface InfrawalletReportCollector {
-  collectReports(
-    entityNamespace: string,
-    entityName: string,
-    queryParameters: ReportParameters,
-  ): Promise<{ reports: Report[]; clientErrors: CloudProviderError[] }>;
+export interface InfrawalletFilterExtension {
+  augmentFilters(parameters: ReportParameters): ReportParameters;
 }
 
-export interface InfrawalletEntityReportExtensionPoint {
-  addReportCollector(collector: InfrawalletReportCollector): void;
+export interface InfrawalletReportFilterExtensionPoint {
+  addReportFilter(filter: InfrawalletFilterExtension): void;
 }
 
-export const infrawalletEntityReportExtensionPoint = createExtensionPoint<InfrawalletEntityReportExtensionPoint>({
-  id: 'infrawallet.entity.report',
+export const infrawalletReportFilterExtensionPoint = createExtensionPoint<InfrawalletReportFilterExtensionPoint>({
+  id: 'infrawallet.report.filter',
 });

--- a/plugins/infrawallet-backend/src/extension.ts
+++ b/plugins/infrawallet-backend/src/extension.ts
@@ -2,7 +2,7 @@ import { createExtensionPoint } from '@backstage/backend-plugin-api';
 import { ReportParameters } from './service/types';
 
 export interface InfrawalletFilterExtension {
-  augmentFilters(parameters: ReportParameters): ReportParameters;
+  augmentFilters(parameters: ReportParameters): Promise<ReportParameters>;
 }
 
 export interface InfrawalletReportFilterExtensionPoint {

--- a/plugins/infrawallet-backend/src/extension.ts
+++ b/plugins/infrawallet-backend/src/extension.ts
@@ -1,0 +1,23 @@
+import { createExtensionPoint } from '@backstage/backend-plugin-api';
+import { CloudProviderError, Report, Tag } from './service/types';
+
+export interface InfrawalletReportCollector {
+  collectReports(
+    entityNamespace: string,
+    entityName: string,
+    filters: string,
+    tags: Tag[],
+    groups: string,
+    granularityString: string,
+    startTime: string,
+    endTime: string,
+  ): Promise<{ reports: Report[]; clientErrors: CloudProviderError[] }>;
+}
+
+export interface InfrawalletEntityReportExtensionPoint {
+  addReportCollector(collector: InfrawalletReportCollector): void;
+}
+
+export const infrawalletEntityReportExtensionPoint = createExtensionPoint<InfrawalletEntityReportExtensionPoint>({
+  id: 'infrawallet.entity.report',
+});

--- a/plugins/infrawallet-backend/src/extension.ts
+++ b/plugins/infrawallet-backend/src/extension.ts
@@ -1,16 +1,11 @@
 import { createExtensionPoint } from '@backstage/backend-plugin-api';
-import { CloudProviderError, Report, Tag } from './service/types';
+import { CloudProviderError, Report, ReportParameters } from './service/types';
 
 export interface InfrawalletReportCollector {
   collectReports(
     entityNamespace: string,
     entityName: string,
-    filters: string,
-    tags: Tag[],
-    groups: string,
-    granularityString: string,
-    startTime: string,
-    endTime: string,
+    queryParameters: ReportParameters,
   ): Promise<{ reports: Report[]; clientErrors: CloudProviderError[] }>;
 }
 

--- a/plugins/infrawallet-backend/src/index.ts
+++ b/plugins/infrawallet-backend/src/index.ts
@@ -3,4 +3,3 @@ export type { InfrawalletFilterExtension, InfrawalletReportFilterExtensionPoint 
 export { infraWalletPlugin as default } from './plugin';
 export * from './service/router';
 export type { ReportParameters, Tag } from './service/types';
-

--- a/plugins/infrawallet-backend/src/index.ts
+++ b/plugins/infrawallet-backend/src/index.ts
@@ -2,4 +2,5 @@ export { infrawalletReportFilterExtensionPoint } from './extension';
 export type { InfrawalletFilterExtension, InfrawalletReportFilterExtensionPoint } from './extension';
 export { infraWalletPlugin as default } from './plugin';
 export * from './service/router';
-export type { ReportParameters } from './service/types';
+export type { ReportParameters, Tag } from './service/types';
+

--- a/plugins/infrawallet-backend/src/index.ts
+++ b/plugins/infrawallet-backend/src/index.ts
@@ -2,3 +2,4 @@ export { infrawalletReportFilterExtensionPoint } from './extension';
 export type { InfrawalletFilterExtension, InfrawalletReportFilterExtensionPoint } from './extension';
 export { infraWalletPlugin as default } from './plugin';
 export * from './service/router';
+export type { ReportParameters } from './service/types';

--- a/plugins/infrawallet-backend/src/index.ts
+++ b/plugins/infrawallet-backend/src/index.ts
@@ -1,2 +1,4 @@
-export * from './service/router';
+export { infrawalletReportFilterExtensionPoint } from './extension';
+export type { InfrawalletFilterExtension, InfrawalletReportFilterExtensionPoint } from './extension';
 export { infraWalletPlugin as default } from './plugin';
+export * from './service/router';

--- a/plugins/infrawallet-backend/src/plugin.ts
+++ b/plugins/infrawallet-backend/src/plugin.ts
@@ -1,6 +1,6 @@
 import { coreServices, createBackendPlugin } from '@backstage/backend-plugin-api';
 import { Logger } from 'winston';
-import { infrawalletEntityReportExtensionPoint, InfrawalletReportCollector } from './extension';
+import { InfrawalletFilterExtension, infrawalletReportFilterExtensionPoint } from './extension';
 import { createRouter } from './service/router';
 import { CostFetchTaskScheduler } from './service/scheduler';
 
@@ -12,14 +12,11 @@ import { CostFetchTaskScheduler } from './service/scheduler';
 export const infraWalletPlugin = createBackendPlugin({
   pluginId: 'infrawallet',
   register(env) {
-    let entityReportCollector: InfrawalletReportCollector | undefined = undefined;
+    const additionalFilters: Array<InfrawalletFilterExtension> = [];
 
-    env.registerExtensionPoint(infrawalletEntityReportExtensionPoint, {
-      addReportCollector(collector: InfrawalletReportCollector) {
-        if (entityReportCollector) {
-          throw new Error('A report collector has already been registered.');
-        }
-        entityReportCollector = collector;
+    env.registerExtensionPoint(infrawalletReportFilterExtensionPoint, {
+      addReportFilter(filter: InfrawalletFilterExtension) {
+        additionalFilters.push(filter);
       },
     });
 
@@ -41,7 +38,7 @@ export const infraWalletPlugin = createBackendPlugin({
             scheduler,
             cache,
             database,
-            entityReportCollector,
+            additionalFilters,
           }),
         );
 

--- a/plugins/infrawallet-backend/src/service/router.ts
+++ b/plugins/infrawallet-backend/src/service/router.ts
@@ -195,7 +195,7 @@ export async function createRouter(options: RouterOptions): Promise<express.Rout
     const granularityString = request.query.granularity as string;
     const startTime = request.query.startTime as string;
     const endTime = request.query.endTime as string;
-    const [entityNamespace, entityName] = decodeURI(request.query.entity as string)?.split('/') || [];
+    const [entityNamespace, entityName] = decodeURI(request.query.entityName as string)?.split('/') || [];
 
     let reportFilters: ReportParameters = {
       filters,

--- a/plugins/infrawallet-backend/src/service/router.ts
+++ b/plugins/infrawallet-backend/src/service/router.ts
@@ -209,7 +209,7 @@ export async function createRouter(options: RouterOptions): Promise<express.Rout
     };
     if (additionalFilters.length > 0) {
       for (const filter of additionalFilters) {
-        reportFilters = filter.augmentFilters(reportFilters);
+        reportFilters = await filter.augmentFilters(reportFilters);
       }
     }
 

--- a/plugins/infrawallet-backend/src/service/router.ts
+++ b/plugins/infrawallet-backend/src/service/router.ts
@@ -1,5 +1,6 @@
 import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
-import { DatabaseService, resolvePackagePath } from '@backstage/backend-plugin-api';
+import { CacheService, DatabaseService, LoggerService, resolvePackagePath } from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config/index';
 import express from 'express';
 import Router from 'express-promise-router';
 import {
@@ -40,8 +41,95 @@ async function setUpDatabase(database: DatabaseService) {
   await client.seed.run({ directory: seedsDir });
 }
 
+async function getReports(
+  filters: string,
+  tags: Tag[],
+  groups: string,
+  granularityString: string,
+  startTime: string,
+  endTime: string,
+  config: Config,
+  database: DatabaseService,
+  cache: CacheService,
+  logger: LoggerService,
+): Promise<{ reports: Report[]; clientErrors: CloudProviderError[] }> {
+  const promises: Promise<void>[] = [];
+  const results: Report[] = [];
+  const errors: CloudProviderError[] = [];
+
+  const granularity: GRANULARITY = Object.values(GRANULARITY).includes(granularityString as GRANULARITY)
+    ? (granularityString as GRANULARITY)
+    : GRANULARITY.MONTHLY;
+
+  // group tags by providers
+  const providerTags: Record<string, Tag[]> = {};
+  for (const tag of tags) {
+    const provider = tag.provider.toLowerCase();
+    if (!providerTags[provider]) {
+      providerTags[provider] = [];
+    }
+
+    providerTags[provider].push(tag);
+  }
+
+  const categoryMappingService = CategoryMappingService.getInstance();
+  await categoryMappingService.refreshCategoryMappings();
+
+  const conf = config.getConfig('backend.infraWallet.integrations');
+  conf
+    .keys()
+    .concat(['custom'])
+    .forEach((provider: string) => {
+      if (provider in COST_CLIENT_MAPPINGS) {
+        const client: InfraWalletClient = COST_CLIENT_MAPPINGS[provider].create(config, database, cache, logger);
+        const fetchCloudCosts = (async () => {
+          try {
+            const clientResponse = await client.getCostReports({
+              filters: filters,
+              tags: tagsToString(providerTags[provider.toLowerCase()]),
+              groups: groups,
+              granularity: granularity,
+              startTime: startTime,
+              endTime: endTime,
+            });
+            clientResponse.errors.forEach((e: CloudProviderError) => {
+              errors.push(e);
+            });
+            clientResponse.reports.forEach((cost: Report) => {
+              results.push(cost);
+            });
+          } catch (e) {
+            logger.error(e);
+            errors.push({
+              provider: client.constructor.name,
+              name: client.constructor.name,
+              error: e.message,
+            });
+          }
+        })();
+        promises.push(fetchCloudCosts);
+      }
+    });
+
+  await Promise.all(promises);
+
+  const parsedFilters = parseFilters(filters);
+
+  const filteredResults = results.filter(report => {
+    return Object.entries(parsedFilters).every(([key, values]) => {
+      const reportValue = report[key];
+      if (typeof reportValue !== 'string') {
+        return false;
+      }
+      return values.includes(reportValue);
+    });
+  });
+
+  return { reports: filteredResults, clientErrors: errors };
+}
+
 export async function createRouter(options: RouterOptions): Promise<express.Router> {
-  const { logger, config, scheduler, cache, database } = options;
+  const { logger, config, scheduler, cache, database, entityReportCollector } = options;
   // do database migrations here to support the legacy backend system
   await setUpDatabase(database);
 
@@ -111,82 +199,72 @@ export async function createRouter(options: RouterOptions): Promise<express.Rout
     const granularityString = request.query.granularity as string;
     const startTime = request.query.startTime as string;
     const endTime = request.query.endTime as string;
-    const promises: Promise<void>[] = [];
-    const results: Report[] = [];
-    const errors: CloudProviderError[] = [];
 
-    const granularity: GRANULARITY = Object.values(GRANULARITY).includes(granularityString as GRANULARITY)
-      ? (granularityString as GRANULARITY)
-      : GRANULARITY.MONTHLY;
+    const { reports, clientErrors } = await getReports(
+      filters,
+      tags,
+      groups,
+      granularityString,
+      startTime,
+      endTime,
+      config,
+      database,
+      cache,
+      logger,
+    );
 
-    // group tags by providers
-    const providerTags: Record<string, Tag[]> = {};
-    for (const tag of tags) {
-      const provider = tag.provider.toLowerCase();
-      if (!providerTags[provider]) {
-        providerTags[provider] = [];
-      }
+    if (clientErrors.length > 0) {
+      response.status(207).json({ data: reports, errors: clientErrors, status: 207 });
+    } else {
+      response.json({ data: reports, errors: clientErrors, status: 200 });
+    }
+  });
 
-      providerTags[provider].push(tag);
+  router.get('/reports/:entityName', async (request, response) => {
+    const [entityNamespace, entityName] = decodeURIComponent(request.params.entityName).split('/');
+    const filters = request.query.filters as string;
+    const tags = parseTags(request.query.tags as string);
+    const groups = request.query.groups as string;
+    const granularityString = request.query.granularity as string;
+    const startTime = request.query.startTime as string;
+    const endTime = request.query.endTime as string;
+    let results: Report[];
+    let errors: CloudProviderError[];
+
+    if (!entityReportCollector) {
+      const { reports, clientErrors } = await getReports(
+        filters,
+        tags,
+        groups,
+        granularityString,
+        startTime,
+        endTime,
+        config,
+        database,
+        cache,
+        logger,
+      );
+      results = reports;
+      errors = clientErrors;
+    } else {
+      const { reports, clientErrors } = await entityReportCollector.collectReports(
+        entityNamespace,
+        entityName,
+        filters,
+        tags,
+        groups,
+        granularityString,
+        startTime,
+        endTime,
+      );
+      results = reports;
+      errors = clientErrors;
     }
 
-    const categoryMappingService = CategoryMappingService.getInstance();
-    await categoryMappingService.refreshCategoryMappings();
-
-    const conf = config.getConfig('backend.infraWallet.integrations');
-    conf
-      .keys()
-      .concat(['custom'])
-      .forEach((provider: string) => {
-        if (provider in COST_CLIENT_MAPPINGS) {
-          const client: InfraWalletClient = COST_CLIENT_MAPPINGS[provider].create(config, database, cache, logger);
-          const fetchCloudCosts = (async () => {
-            try {
-              const clientResponse = await client.getCostReports({
-                filters: filters,
-                tags: tagsToString(providerTags[provider.toLowerCase()]),
-                groups: groups,
-                granularity: granularity,
-                startTime: startTime,
-                endTime: endTime,
-              });
-              clientResponse.errors.forEach((e: CloudProviderError) => {
-                errors.push(e);
-              });
-              clientResponse.reports.forEach((cost: Report) => {
-                results.push(cost);
-              });
-            } catch (e) {
-              logger.error(e);
-              errors.push({
-                provider: client.constructor.name,
-                name: client.constructor.name,
-                error: e.message,
-              });
-            }
-          })();
-          promises.push(fetchCloudCosts);
-        }
-      });
-
-    await Promise.all(promises);
-
-    const parsedFilters = parseFilters(filters);
-
-    const filteredResults = results.filter(report => {
-      return Object.entries(parsedFilters).every(([key, values]) => {
-        const reportValue = report[key];
-        if (typeof reportValue !== 'string') {
-          return false;
-        }
-        return values.includes(reportValue);
-      });
-    });
-
     if (errors.length > 0) {
-      response.status(207).json({ data: filteredResults, errors: errors, status: 207 });
+      response.status(207).json({ data: results, errors: errors, status: 207 });
     } else {
-      response.json({ data: filteredResults, errors: errors, status: 200 });
+      response.json({ data: results, errors: errors, status: 200 });
     }
   });
 

--- a/plugins/infrawallet-backend/src/service/scheduler.ts
+++ b/plugins/infrawallet-backend/src/service/scheduler.ts
@@ -57,6 +57,7 @@ export class CostFetchTaskScheduler {
           scheduler: this.scheduler,
           cache: this.cache,
           database: this.database,
+          additionalFilters: [],
         };
 
         await fetchAndSaveCosts(routerOptions);

--- a/plugins/infrawallet-backend/src/service/types.ts
+++ b/plugins/infrawallet-backend/src/service/types.ts
@@ -1,5 +1,6 @@
 import { CacheService, DatabaseService, LoggerService, SchedulerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
+import { InfrawalletReportCollector } from '../extension';
 import { GRANULARITY } from './consts';
 
 export interface RouterOptions {
@@ -8,6 +9,7 @@ export interface RouterOptions {
   scheduler: SchedulerService;
   cache: CacheService;
   database: DatabaseService;
+  entityReportCollector: InfrawalletReportCollector | undefined;
 }
 
 export type CategoryMappings = {

--- a/plugins/infrawallet-backend/src/service/types.ts
+++ b/plugins/infrawallet-backend/src/service/types.ts
@@ -1,6 +1,6 @@
 import { CacheService, DatabaseService, LoggerService, SchedulerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
-import { InfrawalletReportCollector } from '../extension';
+import { InfrawalletFilterExtension } from '../extension';
 import { GRANULARITY } from './consts';
 
 export interface RouterOptions {
@@ -9,7 +9,7 @@ export interface RouterOptions {
   scheduler: SchedulerService;
   cache: CacheService;
   database: DatabaseService;
-  entityReportCollector?: InfrawalletReportCollector;
+  additionalFilters: Array<InfrawalletFilterExtension>;
 }
 
 export type CategoryMappings = {
@@ -55,6 +55,8 @@ export type ReportParameters = {
   granularityString: string;
   startTime: string;
   endTime: string;
+  entityNamespace?: string;
+  entityName?: string;
 };
 
 export type Tag = {

--- a/plugins/infrawallet-backend/src/service/types.ts
+++ b/plugins/infrawallet-backend/src/service/types.ts
@@ -9,7 +9,7 @@ export interface RouterOptions {
   scheduler: SchedulerService;
   cache: CacheService;
   database: DatabaseService;
-  entityReportCollector: InfrawalletReportCollector | undefined;
+  entityReportCollector?: InfrawalletReportCollector;
 }
 
 export type CategoryMappings = {

--- a/plugins/infrawallet-backend/src/service/types.ts
+++ b/plugins/infrawallet-backend/src/service/types.ts
@@ -48,6 +48,15 @@ export type Report = {
   [key: string]: string | number | { [period: string]: number } | undefined;
 };
 
+export type ReportParameters = {
+  filters: string;
+  tags: Tag[];
+  groups: string;
+  granularityString: string;
+  startTime: string;
+  endTime: string;
+};
+
 export type Tag = {
   key: string;
   value?: string;

--- a/plugins/infrawallet/src/api/InfraWalletApi.ts
+++ b/plugins/infrawallet/src/api/InfraWalletApi.ts
@@ -29,6 +29,15 @@ export interface InfraWalletApi {
     startTime: Date,
     endTime: Date,
   ): Promise<CostReportsResponse>;
+  getEntityCostReports(
+    entityName: string,
+    filters: string,
+    tags: Tag[],
+    groups: string,
+    granularity: string,
+    startTime: Date,
+    endTime: Date,
+  ): Promise<CostReportsResponse>;
   getTagKeys(provider: string, startTime: Date, endTime: Date): Promise<TagResponse>;
   getTagValues(tag: Tag, startTime: Date, endTime: Date): Promise<TagResponse>;
   getBudgets(walletName: string): Promise<BudgetsResponse>;

--- a/plugins/infrawallet/src/api/InfraWalletApi.ts
+++ b/plugins/infrawallet/src/api/InfraWalletApi.ts
@@ -28,15 +28,7 @@ export interface InfraWalletApi {
     granularity: string,
     startTime: Date,
     endTime: Date,
-  ): Promise<CostReportsResponse>;
-  getEntityCostReports(
-    entityName: string,
-    filters: string,
-    tags: Tag[],
-    groups: string,
-    granularity: string,
-    startTime: Date,
-    endTime: Date,
+    entityName?: string,
   ): Promise<CostReportsResponse>;
   getTagKeys(provider: string, startTime: Date, endTime: Date): Promise<TagResponse>;
   getTagValues(tag: Tag, startTime: Date, endTime: Date): Promise<TagResponse>;

--- a/plugins/infrawallet/src/api/InfraWalletApiClient.ts
+++ b/plugins/infrawallet/src/api/InfraWalletApiClient.ts
@@ -63,10 +63,10 @@ export class InfraWalletApiClient implements InfraWalletApi {
     granularity: string,
     startTime: Date,
     endTime: Date,
-    entityName: string,
+    entityName?: string,
   ): Promise<CostReportsResponse> {
     const tagsString = tagsToString(tags);
-    const url = `api/infrawallet/reports?granularity=${granularity}&groups=${groups}&filters=${filters}&tags=${tagsString}&startTime=${startTime.getTime()}&endTime=${endTime.getTime()}&entityName=${entityName}`;
+    const url = `api/infrawallet/reports?granularity=${granularity}&groups=${groups}&filters=${filters}&tags=${tagsString}&startTime=${startTime.getTime()}&endTime=${endTime.getTime()}${entityName ? `&entityName=${entityName}` : ''}`;
 
     return await this.request(url);
   }

--- a/plugins/infrawallet/src/api/InfraWalletApiClient.ts
+++ b/plugins/infrawallet/src/api/InfraWalletApiClient.ts
@@ -66,7 +66,8 @@ export class InfraWalletApiClient implements InfraWalletApi {
     entityName?: string,
   ): Promise<CostReportsResponse> {
     const tagsString = tagsToString(tags);
-    const url = `api/infrawallet/reports?granularity=${granularity}&groups=${groups}&filters=${filters}&tags=${tagsString}&startTime=${startTime.getTime()}&endTime=${endTime.getTime()}${entityName ? `&entityName=${entityName}` : ''}`;
+    const entityNameParam = entityName ? `&entityName=${entityName}` : '';
+    const url = `api/infrawallet/reports?granularity=${granularity}&groups=${groups}&filters=${filters}&tags=${tagsString}&startTime=${startTime.getTime()}&endTime=${endTime.getTime()}${entityNameParam}`;
 
     return await this.request(url);
   }

--- a/plugins/infrawallet/src/api/InfraWalletApiClient.ts
+++ b/plugins/infrawallet/src/api/InfraWalletApiClient.ts
@@ -63,24 +63,10 @@ export class InfraWalletApiClient implements InfraWalletApi {
     granularity: string,
     startTime: Date,
     endTime: Date,
-  ): Promise<CostReportsResponse> {
-    const tagsString = tagsToString(tags);
-    const url = `api/infrawallet/reports?granularity=${granularity}&groups=${groups}&filters=${filters}&tags=${tagsString}&startTime=${startTime.getTime()}&endTime=${endTime.getTime()}`;
-
-    return await this.request(url);
-  }
-
-  async getEntityCostReports(
     entityName: string,
-    filters: string,
-    tags: Tag[],
-    groups: string,
-    granularity: string,
-    startTime: Date,
-    endTime: Date,
   ): Promise<CostReportsResponse> {
     const tagsString = tagsToString(tags);
-    const url = `api/infrawallet/reports/${entityName}?granularity=${granularity}&groups=${groups}&filters=${filters}&tags=${tagsString}&startTime=${startTime.getTime()}&endTime=${endTime.getTime()}`;
+    const url = `api/infrawallet/reports?granularity=${granularity}&groups=${groups}&filters=${filters}&tags=${tagsString}&startTime=${startTime.getTime()}&endTime=${endTime.getTime()}&entityName=${entityName}`;
 
     return await this.request(url);
   }

--- a/plugins/infrawallet/src/api/InfraWalletApiClient.ts
+++ b/plugins/infrawallet/src/api/InfraWalletApiClient.ts
@@ -70,6 +70,21 @@ export class InfraWalletApiClient implements InfraWalletApi {
     return await this.request(url);
   }
 
+  async getEntityCostReports(
+    entityName: string,
+    filters: string,
+    tags: Tag[],
+    groups: string,
+    granularity: string,
+    startTime: Date,
+    endTime: Date,
+  ): Promise<CostReportsResponse> {
+    const tagsString = tagsToString(tags);
+    const url = `api/infrawallet/reports/${entityName}?granularity=${granularity}&groups=${groups}&filters=${filters}&tags=${tagsString}&startTime=${startTime.getTime()}&endTime=${endTime.getTime()}`;
+
+    return await this.request(url);
+  }
+
   async getTagKeys(provider: string, startTime: Date, endTime: Date): Promise<TagResponse> {
     const url = `api/infrawallet/tag-keys?provider=${provider}&startTime=${startTime.getTime()}&endTime=${endTime.getTime()}`;
     return await this.request(url);

--- a/plugins/infrawallet/src/components/EntityInfraWalletCard/EntityInfraWalletCard.tsx
+++ b/plugins/infrawallet/src/components/EntityInfraWalletCard/EntityInfraWalletCard.tsx
@@ -1,3 +1,4 @@
+import { Entity } from '@backstage/catalog-model';
 import { InfoCard, Progress } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
@@ -13,7 +14,7 @@ import Tabs from '@mui/material/Tabs';
 import Typography from '@mui/material/Typography';
 import { default as React, useEffect, useState } from 'react';
 import { CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
-import { infraWalletApiRef } from '../../api/InfraWalletApi';
+import { InfraWalletApi, infraWalletApiRef } from '../../api/InfraWalletApi';
 import { CostReportsResponse, Report, Tag } from '../../api/types';
 
 const COLORS = [
@@ -29,7 +30,12 @@ const COLORS = [
   '#00ffff',
 ];
 
-async function getFilteredCostReports(infrawalletApi: any, filters: string, tags: Tag[]): Promise<Report[] | null> {
+async function getFilteredCostReports(
+  infrawalletApi: InfraWalletApi,
+  entity: Entity,
+  filters: string,
+  tags: Tag[],
+): Promise<Report[] | null> {
   const groups = '';
   const granularity = 'monthly';
 
@@ -37,7 +43,8 @@ async function getFilteredCostReports(infrawalletApi: any, filters: string, tags
   const startTime = new Date();
   startTime.setMonth(endTime.getMonth() - 2);
 
-  const costReportsResponse: CostReportsResponse = await infrawalletApi.getCostReports(
+  const costReportsResponse: CostReportsResponse = await infrawalletApi.getEntityCostReports(
+    encodeURIComponent(`${entity.metadata.namespace}/${entity.metadata.name}`),
     filters,
     tags,
     groups,
@@ -401,7 +408,7 @@ export const EntityInfraWalletCard = () => {
 
       let costReports: Report[] | null = [];
       try {
-        costReports = await getFilteredCostReports(infrawalletApi, filters, tags);
+        costReports = await getFilteredCostReports(infrawalletApi, entity, filters, tags);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch cost reports');
         setErrorSeverity('error');

--- a/plugins/infrawallet/src/components/EntityInfraWalletCard/EntityInfraWalletCard.tsx
+++ b/plugins/infrawallet/src/components/EntityInfraWalletCard/EntityInfraWalletCard.tsx
@@ -43,14 +43,14 @@ async function getFilteredCostReports(
   const startTime = new Date();
   startTime.setMonth(endTime.getMonth() - 2);
 
-  const costReportsResponse: CostReportsResponse = await infrawalletApi.getEntityCostReports(
-    encodeURIComponent(`${entity.metadata.namespace}/${entity.metadata.name}`),
+  const costReportsResponse: CostReportsResponse = await infrawalletApi.getCostReports(
     filters,
     tags,
     groups,
     granularity,
     startTime,
     endTime,
+    encodeURI(`${entity.metadata.namespace}/${entity.metadata.name}`),
   );
 
   if (costReportsResponse.status !== 200) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2993,19 +2993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@npm:^1.7.3, @backstage/catalog-model@npm:^1.7.4":
-  version: 1.7.4
-  resolution: "@backstage/catalog-model@npm:1.7.4"
-  dependencies:
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/types": "npm:^1.2.1"
-    ajv: "npm:^8.10.0"
-    lodash: "npm:^4.17.21"
-  checksum: 10/48c2db2a8144e891319879cec6cae1980088165a910a757b8ebc07dc337b4d8d5c743fbaa3fa916cdd1b5e06635b3a3edbd1e7d8519ac135824f1ba37c5e3ce2
-  languageName: node
-  linkType: hard
-
-"@backstage/catalog-model@npm:^1.7.5":
+"@backstage/catalog-model@npm:^1.7.3, @backstage/catalog-model@npm:^1.7.4, @backstage/catalog-model@npm:^1.7.5":
   version: 1.7.5
   resolution: "@backstage/catalog-model@npm:1.7.5"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3005,6 +3005,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/catalog-model@npm:^1.7.5":
+  version: 1.7.5
+  resolution: "@backstage/catalog-model@npm:1.7.5"
+  dependencies:
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/types": "npm:^1.2.1"
+    ajv: "npm:^8.10.0"
+    lodash: "npm:^4.17.21"
+  checksum: 10/857a93cc04ef7ad427b4c9a65792b750c6c2664348d00abddffe25f4eb909c5c54a0610ca44e7a5f8b374a30b723e0e00b48f4d93407b7575c0ad6a94055946a
+  languageName: node
+  linkType: hard
+
 "@backstage/cli-common@npm:^0.1.14, @backstage/cli-common@npm:^0.1.15":
   version: 0.1.15
   resolution: "@backstage/cli-common@npm:0.1.15"
@@ -4230,6 +4242,7 @@ __metadata:
     "@azure/identity": "npm:4.5.0"
     "@backstage/backend-defaults": "npm:^0.11.0"
     "@backstage/backend-plugin-api": "npm:^1.4.0"
+    "@backstage/catalog-model": "npm:^1.7.5"
     "@backstage/cli": "npm:^0.33.0"
     "@backstage/config": "npm:^1.3.2"
     "@backstage/plugin-auth-backend": "npm:^0.25.1"


### PR DESCRIPTION
This PR is an attempt to implement the requirements of #184. By defining an ExtensionPoint the `EntityInfraWalletCard` can (but does not have to) use custom information of an entity to provide more targeted information.