### PR TITLE
feat(budget datapoints):

### DIFF
--- a/docs/getting-started/customization.md
+++ b/docs/getting-started/customization.md
@@ -35,10 +35,10 @@ infraWallet:
   settings:
     budgets:
       enabled: true
-    
+
     businessMetrics:
       enabled: true
 
     customCosts:
-      enabled: false  # hide Custom Costs tab
+      enabled: false # hide Custom Costs tab
 ```

--- a/plugins/infrawallet/src/api/functions.ts
+++ b/plugins/infrawallet/src/api/functions.ts
@@ -236,14 +236,14 @@ export const calculateBudgetAnalytics = (
   const currentYear = moment().year();
   const daysIntoCurrentMonth = moment().date();
   const daysInCurrentMonth = moment().daysInMonth();
-  
+
   let yearToDateSpent = 0;
   const monthlySpending: number[] = [];
-  
+
   for (let month = 1; month <= currentMonth; month++) {
     const monthKey = `${currentYear}-${month.toString().padStart(2, '0')}`;
     const monthCost = monthlyCosts[monthKey] || 0;
-    
+
     if (month < currentMonth) {
       yearToDateSpent += monthCost;
       monthlySpending.push(monthCost);
@@ -253,41 +253,47 @@ export const calculateBudgetAnalytics = (
       monthlySpending.push(projectedCurrentMonthCost);
     }
   }
-  
+
   const monthsRemaining = 12 - currentMonth + (1 - daysIntoCurrentMonth / daysInCurrentMonth);
-  const averageMonthlySpending = monthlySpending.length > 0 ? 
-    monthlySpending.reduce((sum, cost) => sum + cost, 0) / monthlySpending.length : 0;
-  
+  const averageMonthlySpending =
+    monthlySpending.length > 0 ? monthlySpending.reduce((sum, cost) => sum + cost, 0) / monthlySpending.length : 0;
+
   const monthlyRunRate = monthlySpending.length > 0 ? monthlySpending[monthlySpending.length - 1] || 0 : 0;
-  
-  const projectedAnnualSpending = yearToDateSpent + (averageMonthlySpending * monthsRemaining);
-  
+
+  const projectedAnnualSpending = yearToDateSpent + averageMonthlySpending * monthsRemaining;
+
   const budgetUtilizationPercent = annualBudget > 0 ? (yearToDateSpent / annualBudget) * 100 : 0;
   const expectedUtilizationPercent = ((currentMonth - 1 + daysIntoCurrentMonth / daysInCurrentMonth) / 12) * 100;
-  
+
   let budgetHealthStatus: 'healthy' | 'warning' | 'critical' = 'healthy';
   if (budgetUtilizationPercent > expectedUtilizationPercent + 20) {
     budgetHealthStatus = 'critical';
   } else if (budgetUtilizationPercent > expectedUtilizationPercent + 10) {
     budgetHealthStatus = 'warning';
   }
-  
-  const targetMonthlySpending = monthsRemaining > 0 ? 
-    (annualBudget - yearToDateSpent) / monthsRemaining : 0;
-  
-  const spendingVariance = monthlySpending.length > 1 ? 
-    Math.sqrt(monthlySpending.reduce((sum, cost) => 
-      sum + Math.pow(cost - averageMonthlySpending, 2), 0) / (monthlySpending.length - 1)) : 0;
-  
-  const spendingVelocity = monthlySpending.length >= 2 ? 
-    ((monthlySpending[monthlySpending.length - 1] - monthlySpending[monthlySpending.length - 2]) / 
-     monthlySpending[monthlySpending.length - 2]) * 100 : 0;
-  
+
+  const targetMonthlySpending = monthsRemaining > 0 ? (annualBudget - yearToDateSpent) / monthsRemaining : 0;
+
+  const spendingVariance =
+    monthlySpending.length > 1
+      ? Math.sqrt(
+          monthlySpending.reduce((sum, cost) => sum + Math.pow(cost - averageMonthlySpending, 2), 0) /
+            (monthlySpending.length - 1),
+        )
+      : 0;
+
+  const spendingVelocity =
+    monthlySpending.length >= 2
+      ? ((monthlySpending[monthlySpending.length - 1] - monthlySpending[monthlySpending.length - 2]) /
+          monthlySpending[monthlySpending.length - 2]) *
+        100
+      : 0;
+
   const confidenceRange = {
-    low: Math.max(0, projectedAnnualSpending - (spendingVariance * 2 * Math.sqrt(monthsRemaining))),
-    high: projectedAnnualSpending + (spendingVariance * 2 * Math.sqrt(monthsRemaining))
+    low: Math.max(0, projectedAnnualSpending - spendingVariance * 2 * Math.sqrt(monthsRemaining)),
+    high: projectedAnnualSpending + spendingVariance * 2 * Math.sqrt(monthsRemaining),
   };
-  
+
   return {
     yearToDateSpent,
     monthlyRunRate,
@@ -298,6 +304,6 @@ export const calculateBudgetAnalytics = (
     monthsRemaining,
     averageMonthlySpending,
     spendingVelocity,
-    confidenceRange
+    confidenceRange,
   };
 };

--- a/plugins/infrawallet/src/api/functions.ts
+++ b/plugins/infrawallet/src/api/functions.ts
@@ -211,3 +211,93 @@ export const formatCurrency = (number: number, currency?: string): string => {
     notation: 'compact',
   }).format(number);
 };
+
+export interface BudgetAnalytics {
+  yearToDateSpent: number;
+  monthlyRunRate: number;
+  projectedAnnualSpending: number;
+  budgetHealthStatus: 'healthy' | 'warning' | 'critical';
+  budgetUtilizationPercent: number;
+  targetMonthlySpending: number;
+  monthsRemaining: number;
+  averageMonthlySpending: number;
+  spendingVelocity: number;
+  confidenceRange: {
+    low: number;
+    high: number;
+  };
+}
+
+export const calculateBudgetAnalytics = (
+  monthlyCosts: Record<string, number>,
+  annualBudget: number,
+): BudgetAnalytics => {
+  const currentMonth = moment().month() + 1;
+  const currentYear = moment().year();
+  const daysIntoCurrentMonth = moment().date();
+  const daysInCurrentMonth = moment().daysInMonth();
+  
+  let yearToDateSpent = 0;
+  const monthlySpending: number[] = [];
+  
+  for (let month = 1; month <= currentMonth; month++) {
+    const monthKey = `${currentYear}-${month.toString().padStart(2, '0')}`;
+    const monthCost = monthlyCosts[monthKey] || 0;
+    
+    if (month < currentMonth) {
+      yearToDateSpent += monthCost;
+      monthlySpending.push(monthCost);
+    } else if (month === currentMonth) {
+      const projectedCurrentMonthCost = (monthCost / daysIntoCurrentMonth) * daysInCurrentMonth;
+      yearToDateSpent += monthCost;
+      monthlySpending.push(projectedCurrentMonthCost);
+    }
+  }
+  
+  const monthsRemaining = 12 - currentMonth + (1 - daysIntoCurrentMonth / daysInCurrentMonth);
+  const averageMonthlySpending = monthlySpending.length > 0 ? 
+    monthlySpending.reduce((sum, cost) => sum + cost, 0) / monthlySpending.length : 0;
+  
+  const monthlyRunRate = monthlySpending.length > 0 ? monthlySpending[monthlySpending.length - 1] || 0 : 0;
+  
+  const projectedAnnualSpending = yearToDateSpent + (averageMonthlySpending * monthsRemaining);
+  
+  const budgetUtilizationPercent = annualBudget > 0 ? (yearToDateSpent / annualBudget) * 100 : 0;
+  const expectedUtilizationPercent = ((currentMonth - 1 + daysIntoCurrentMonth / daysInCurrentMonth) / 12) * 100;
+  
+  let budgetHealthStatus: 'healthy' | 'warning' | 'critical' = 'healthy';
+  if (budgetUtilizationPercent > expectedUtilizationPercent + 20) {
+    budgetHealthStatus = 'critical';
+  } else if (budgetUtilizationPercent > expectedUtilizationPercent + 10) {
+    budgetHealthStatus = 'warning';
+  }
+  
+  const targetMonthlySpending = monthsRemaining > 0 ? 
+    (annualBudget - yearToDateSpent) / monthsRemaining : 0;
+  
+  const spendingVariance = monthlySpending.length > 1 ? 
+    Math.sqrt(monthlySpending.reduce((sum, cost) => 
+      sum + Math.pow(cost - averageMonthlySpending, 2), 0) / (monthlySpending.length - 1)) : 0;
+  
+  const spendingVelocity = monthlySpending.length >= 2 ? 
+    ((monthlySpending[monthlySpending.length - 1] - monthlySpending[monthlySpending.length - 2]) / 
+     monthlySpending[monthlySpending.length - 2]) * 100 : 0;
+  
+  const confidenceRange = {
+    low: Math.max(0, projectedAnnualSpending - (spendingVariance * 2 * Math.sqrt(monthsRemaining))),
+    high: projectedAnnualSpending + (spendingVariance * 2 * Math.sqrt(monthsRemaining))
+  };
+  
+  return {
+    yearToDateSpent,
+    monthlyRunRate,
+    projectedAnnualSpending,
+    budgetHealthStatus,
+    budgetUtilizationPercent,
+    targetMonthlySpending,
+    monthsRemaining,
+    averageMonthlySpending,
+    spendingVelocity,
+    confidenceRange
+  };
+};

--- a/plugins/infrawallet/src/components/Budgets/Budgets.tsx
+++ b/plugins/infrawallet/src/components/Budgets/Budgets.tsx
@@ -36,7 +36,13 @@ import {
 import { max } from 'lodash';
 import moment from 'moment';
 import React, { FC, useCallback, useEffect, useState } from 'react';
-import { aggregateCostReports, formatCurrency, mergeCostReports, calculateBudgetAnalytics, BudgetAnalytics } from '../../api/functions';
+import {
+  aggregateCostReports,
+  formatCurrency,
+  mergeCostReports,
+  calculateBudgetAnalytics,
+  BudgetAnalytics,
+} from '../../api/functions';
 import { infraWalletApiRef } from '../../api/InfraWalletApi';
 import { Budget, Report } from '../../api/types';
 import { colorList } from '../constants';
@@ -71,19 +77,27 @@ interface BudgetHealthIndicatorProps {
 function BudgetHealthIndicator({ status, utilizationPercent }: BudgetHealthIndicatorProps) {
   const getStatusColor = () => {
     switch (status) {
-      case 'healthy': return '#4caf50';
-      case 'warning': return '#ff9800';
-      case 'critical': return '#f44336';
-      default: return '#9e9e9e';
+      case 'healthy':
+        return '#4caf50';
+      case 'warning':
+        return '#ff9800';
+      case 'critical':
+        return '#f44336';
+      default:
+        return '#9e9e9e';
     }
   };
 
   const getStatusLabel = () => {
     switch (status) {
-      case 'healthy': return 'On Track';
-      case 'warning': return 'At Risk';
-      case 'critical': return 'Over Budget';
-      default: return 'Unknown';
+      case 'healthy':
+        return 'On Track';
+      case 'warning':
+        return 'At Risk';
+      case 'critical':
+        return 'Over Budget';
+      default:
+        return 'Unknown';
     }
   };
 
@@ -95,7 +109,7 @@ function BudgetHealthIndicator({ status, utilizationPercent }: BudgetHealthIndic
         backgroundColor: getStatusColor(),
         color: 'white',
         fontWeight: 'bold',
-        '& .MuiChip-label': { fontWeight: 'bold' }
+        '& .MuiChip-label': { fontWeight: 'bold' },
       }}
     />
   );
@@ -136,10 +150,7 @@ function BudgetChart(props: Readonly<BudgetChartProps>) {
 
   const infraWalletApi = useApi(infraWalletApiRef);
 
-  const budgetAnalytics: BudgetAnalytics = calculateBudgetAnalytics(
-    monthlyCosts,
-    annualBudget?.amount || 0
-  );
+  const budgetAnalytics: BudgetAnalytics = calculateBudgetAnalytics(monthlyCosts, annualBudget?.amount || 0);
 
   useEffect(() => {
     const fetchBudget = async () => {
@@ -194,7 +205,6 @@ function BudgetChart(props: Readonly<BudgetChartProps>) {
     budgetAmount = budgetAmount / 12;
   }
 
-
   return (
     <Paper sx={{ padding: 2 }}>
       {/* Budget Health Header */}
@@ -206,8 +216,8 @@ function BudgetChart(props: Readonly<BudgetChartProps>) {
           </Typography>
         </Box>
         {annualBudget?.amount && (
-          <BudgetHealthIndicator 
-            status={budgetAnalytics.budgetHealthStatus} 
+          <BudgetHealthIndicator
+            status={budgetAnalytics.budgetHealthStatus}
             utilizationPercent={budgetAnalytics.budgetUtilizationPercent}
           />
         )}
@@ -237,17 +247,17 @@ function BudgetChart(props: Readonly<BudgetChartProps>) {
                 <Typography variant="caption" color="textSecondary">
                   Projected Annual
                 </Typography>
-                <Typography 
-                  variant="body2" 
+                <Typography
+                  variant="body2"
                   fontWeight="bold"
                   color={budgetAnalytics.projectedAnnualSpending > (annualBudget?.amount || 0) ? 'error' : 'inherit'}
                 >
                   {formatCurrency(budgetAnalytics.projectedAnnualSpending)}
                 </Typography>
                 <Typography variant="caption" color="textSecondary">
-                  {budgetAnalytics.projectedAnnualSpending > (annualBudget?.amount || 0) ? 
-                    `+${formatCurrency(budgetAnalytics.projectedAnnualSpending - annualBudget.amount)} over` : 
-                    `${formatCurrency(annualBudget.amount - budgetAnalytics.projectedAnnualSpending)} under`}
+                  {budgetAnalytics.projectedAnnualSpending > (annualBudget?.amount || 0)
+                    ? `+${formatCurrency(budgetAnalytics.projectedAnnualSpending - annualBudget.amount)} over`
+                    : `${formatCurrency(annualBudget.amount - budgetAnalytics.projectedAnnualSpending)} under`}
                 </Typography>
               </CardContent>
             </Card>
@@ -261,11 +271,8 @@ function BudgetChart(props: Readonly<BudgetChartProps>) {
                 <Typography variant="body2" fontWeight="bold">
                   {formatCurrency(budgetAnalytics.monthlyRunRate)}
                 </Typography>
-                <Typography 
-                  variant="caption" 
-                  color={getSpendingVelocityColor(budgetAnalytics.spendingVelocity)}
-                >
-                  {getSpendingVelocityIcon(budgetAnalytics.spendingVelocity)} 
+                <Typography variant="caption" color={getSpendingVelocityColor(budgetAnalytics.spendingVelocity)}>
+                  {getSpendingVelocityIcon(budgetAnalytics.spendingVelocity)}
                   {Math.abs(budgetAnalytics.spendingVelocity).toFixed(1)}% MoM
                 </Typography>
               </CardContent>
@@ -277,10 +284,12 @@ function BudgetChart(props: Readonly<BudgetChartProps>) {
                 <Typography variant="caption" color="textSecondary">
                   Target Monthly
                 </Typography>
-                <Typography 
-                  variant="body2" 
+                <Typography
+                  variant="body2"
                   fontWeight="bold"
-                  color={budgetAnalytics.targetMonthlySpending < budgetAnalytics.monthlyRunRate ? 'error' : 'success.main'}
+                  color={
+                    budgetAnalytics.targetMonthlySpending < budgetAnalytics.monthlyRunRate ? 'error' : 'success.main'
+                  }
                 >
                   {formatCurrency(budgetAnalytics.targetMonthlySpending)}
                 </Typography>
@@ -397,8 +406,7 @@ function BudgetChart(props: Readonly<BudgetChartProps>) {
         <ChartsYAxis />
         <ChartsTooltip />
       </ChartContainer>
-      
-      
+
       <Box sx={{ textAlign: 'center' }}>
         <Button onClick={() => setOpenManageBudget(true)}>Manage budget</Button>
         <Dialog fullWidth maxWidth="sm" open={openManageBudget} onClose={() => setOpenManageBudget(false)}>
@@ -454,13 +462,15 @@ function BudgetInsights({ reports }: BudgetInsightsProps) {
     fetchBudgets();
   }, [infraWalletApi]);
 
-  const insights = reports.map(report => {
-    const budget = budgets.find(b => b.provider.toLowerCase() === report.id.toLowerCase());
-    if (!budget?.amount) return null;
-    
-    const analytics = calculateBudgetAnalytics(report.reports, budget.amount);
-    return { provider: report.id, budget, analytics };
-  }).filter(Boolean);
+  const insights = reports
+    .map(report => {
+      const budget = budgets.find(b => b.provider.toLowerCase() === report.id.toLowerCase());
+      if (!budget?.amount) return null;
+
+      const analytics = calculateBudgetAnalytics(report.reports, budget.amount);
+      return { provider: report.id, budget, analytics };
+    })
+    .filter(Boolean);
 
   const totalBudget = budgets.reduce((sum, b) => sum + (b.amount || 0), 0);
   const totalProjected = insights.reduce((sum, i) => sum + (i?.analytics.projectedAnnualSpending || 0), 0);
@@ -469,25 +479,25 @@ function BudgetInsights({ reports }: BudgetInsightsProps) {
 
   const getRecommendations = () => {
     const recommendations = [];
-    
+
     if (overBudgetProviders.length > 0) {
       recommendations.push({
         type: 'critical',
-        message: `${overBudgetProviders.length} provider(s) are over budget: ${overBudgetProviders.map(p => p?.provider).join(', ')}`
+        message: `${overBudgetProviders.length} provider(s) are over budget: ${overBudgetProviders.map(p => p?.provider).join(', ')}`,
       });
     }
-    
+
     if (atRiskProviders.length > 0) {
       recommendations.push({
-        type: 'warning', 
-        message: `${atRiskProviders.length} provider(s) at risk: ${atRiskProviders.map(p => p?.provider).join(', ')}`
+        type: 'warning',
+        message: `${atRiskProviders.length} provider(s) at risk: ${atRiskProviders.map(p => p?.provider).join(', ')}`,
       });
     }
-    
+
     if (totalProjected > totalBudget) {
       recommendations.push({
         type: 'info',
-        message: `Total projected spending (${formatCurrency(totalProjected)}) exceeds total budget (${formatCurrency(totalBudget)}) by ${formatCurrency(totalProjected - totalBudget)}`
+        message: `Total projected spending (${formatCurrency(totalProjected)}) exceeds total budget (${formatCurrency(totalBudget)}) by ${formatCurrency(totalProjected - totalBudget)}`,
       });
     }
 
@@ -495,7 +505,7 @@ function BudgetInsights({ reports }: BudgetInsightsProps) {
     if (highVelocityProviders.length > 0) {
       recommendations.push({
         type: 'warning',
-        message: `High spending acceleration detected in: ${highVelocityProviders.map(p => p?.provider).join(', ')}`
+        message: `High spending acceleration detected in: ${highVelocityProviders.map(p => p?.provider).join(', ')}`,
       });
     }
 
@@ -509,13 +519,17 @@ function BudgetInsights({ reports }: BudgetInsightsProps) {
   return (
     <Card sx={{ mb: 3 }}>
       <CardContent>
-        <Typography variant="h6" gutterBottom>Budget Insights</Typography>
-        
+        <Typography variant="h6" gutterBottom>
+          Budget Insights
+        </Typography>
+
         {/* Overview Stats */}
         <Grid container spacing={2} sx={{ mb: 2 }}>
           <Grid item xs={3}>
             <Box textAlign="center">
-              <Typography variant="h4" color="primary">{insights.length}</Typography>
+              <Typography variant="h4" color="primary">
+                {insights.length}
+              </Typography>
               <Typography variant="caption">Providers</Typography>
             </Box>
           </Grid>
@@ -548,7 +562,9 @@ function BudgetInsights({ reports }: BudgetInsightsProps) {
         {/* Recommendations */}
         {recommendations.length > 0 && (
           <Box>
-            <Typography variant="subtitle2" gutterBottom>Recommendations</Typography>
+            <Typography variant="subtitle2" gutterBottom>
+              Recommendations
+            </Typography>
             {recommendations.map((rec, index) => (
               <Chip
                 key={index}
@@ -610,7 +626,7 @@ export const Budgets: FC<BudgetsProps> = ({ providerErrorsSetter }) => {
           </Box>
         </Box>
       </Grid>
-      
+
       {/* Budget Insights Panel */}
       {reportsAggregatedAndMerged && (
         <Grid item xs={12}>

--- a/plugins/infrawallet/src/components/Budgets/Budgets.tsx
+++ b/plugins/infrawallet/src/components/Budgets/Budgets.tsx
@@ -1,6 +1,9 @@
 import { alertApiRef, useApi } from '@backstage/core-plugin-api';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
@@ -32,8 +35,8 @@ import {
 } from '@mui/x-charts';
 import { max } from 'lodash';
 import moment from 'moment';
-import { FC, default as React, useCallback, useEffect, useState } from 'react';
-import { aggregateCostReports, formatCurrency, mergeCostReports } from '../../api/functions';
+import React, { FC, useCallback, useEffect, useState } from 'react';
+import { aggregateCostReports, formatCurrency, mergeCostReports, calculateBudgetAnalytics, BudgetAnalytics } from '../../api/functions';
 import { infraWalletApiRef } from '../../api/InfraWalletApi';
 import { Budget, Report } from '../../api/types';
 import { colorList } from '../constants';
@@ -60,10 +63,66 @@ const monthList = {
   '12': 'Dec',
 };
 
+interface BudgetHealthIndicatorProps {
+  status: 'healthy' | 'warning' | 'critical';
+  utilizationPercent: number;
+}
+
+function BudgetHealthIndicator({ status, utilizationPercent }: BudgetHealthIndicatorProps) {
+  const getStatusColor = () => {
+    switch (status) {
+      case 'healthy': return '#4caf50';
+      case 'warning': return '#ff9800';
+      case 'critical': return '#f44336';
+      default: return '#9e9e9e';
+    }
+  };
+
+  const getStatusLabel = () => {
+    switch (status) {
+      case 'healthy': return 'On Track';
+      case 'warning': return 'At Risk';
+      case 'critical': return 'Over Budget';
+      default: return 'Unknown';
+    }
+  };
+
+  return (
+    <Chip
+      label={`${getStatusLabel()} (${utilizationPercent.toFixed(1)}%)`}
+      size="small"
+      sx={{
+        backgroundColor: getStatusColor(),
+        color: 'white',
+        fontWeight: 'bold',
+        '& .MuiChip-label': { fontWeight: 'bold' }
+      }}
+    />
+  );
+}
+
 interface BudgetChartProps {
   provider: string;
   monthlyCosts: Record<string, number>;
   view: string;
+}
+
+function getSpendingVelocityColor(velocity: number) {
+  if (velocity > 10) return 'error';
+  if (velocity < -10) return 'success.main';
+  return 'textSecondary';
+}
+
+function getSpendingVelocityIcon(velocity: number) {
+  if (velocity > 0) return '↑';
+  if (velocity < 0) return '↓';
+  return '→';
+}
+
+function getRecommendationColor(type: string) {
+  if (type === 'critical') return 'error';
+  if (type === 'warning') return 'warning';
+  return 'info';
 }
 
 function BudgetChart(props: Readonly<BudgetChartProps>) {
@@ -76,6 +135,11 @@ function BudgetChart(props: Readonly<BudgetChartProps>) {
   const [refreshTrigger, setRefreshTrigger] = useState(false);
 
   const infraWalletApi = useApi(infraWalletApiRef);
+
+  const budgetAnalytics: BudgetAnalytics = calculateBudgetAnalytics(
+    monthlyCosts,
+    annualBudget?.amount || 0
+  );
 
   useEffect(() => {
     const fetchBudget = async () => {
@@ -130,8 +194,105 @@ function BudgetChart(props: Readonly<BudgetChartProps>) {
     budgetAmount = budgetAmount / 12;
   }
 
+
   return (
     <Paper sx={{ padding: 2 }}>
+      {/* Budget Health Header */}
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <ProviderIcon provider={provider} />
+          <Typography variant="h6" sx={{ ml: 1, fontWeight: 'bold' }}>
+            {provider}
+          </Typography>
+        </Box>
+        {annualBudget?.amount && (
+          <BudgetHealthIndicator 
+            status={budgetAnalytics.budgetHealthStatus} 
+            utilizationPercent={budgetAnalytics.budgetUtilizationPercent}
+          />
+        )}
+      </Box>
+
+      {/* Budget Metrics Cards */}
+      {annualBudget?.amount && (
+        <Grid container spacing={1} sx={{ mb: 2 }}>
+          <Grid item xs={6}>
+            <Card variant="outlined" sx={{ textAlign: 'center' }}>
+              <CardContent sx={{ py: 1, '&:last-child': { pb: 1 } }}>
+                <Typography variant="caption" color="textSecondary">
+                  YTD Spent
+                </Typography>
+                <Typography variant="body2" fontWeight="bold">
+                  {formatCurrency(budgetAnalytics.yearToDateSpent)}
+                </Typography>
+                <Typography variant="caption" color="textSecondary">
+                  of {formatCurrency(annualBudget.amount)}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+          <Grid item xs={6}>
+            <Card variant="outlined" sx={{ textAlign: 'center' }}>
+              <CardContent sx={{ py: 1, '&:last-child': { pb: 1 } }}>
+                <Typography variant="caption" color="textSecondary">
+                  Projected Annual
+                </Typography>
+                <Typography 
+                  variant="body2" 
+                  fontWeight="bold"
+                  color={budgetAnalytics.projectedAnnualSpending > (annualBudget?.amount || 0) ? 'error' : 'inherit'}
+                >
+                  {formatCurrency(budgetAnalytics.projectedAnnualSpending)}
+                </Typography>
+                <Typography variant="caption" color="textSecondary">
+                  {budgetAnalytics.projectedAnnualSpending > (annualBudget?.amount || 0) ? 
+                    `+${formatCurrency(budgetAnalytics.projectedAnnualSpending - annualBudget.amount)} over` : 
+                    `${formatCurrency(annualBudget.amount - budgetAnalytics.projectedAnnualSpending)} under`}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+          <Grid item xs={6}>
+            <Card variant="outlined" sx={{ textAlign: 'center' }}>
+              <CardContent sx={{ py: 1, '&:last-child': { pb: 1 } }}>
+                <Typography variant="caption" color="textSecondary">
+                  Monthly Run Rate
+                </Typography>
+                <Typography variant="body2" fontWeight="bold">
+                  {formatCurrency(budgetAnalytics.monthlyRunRate)}
+                </Typography>
+                <Typography 
+                  variant="caption" 
+                  color={getSpendingVelocityColor(budgetAnalytics.spendingVelocity)}
+                >
+                  {getSpendingVelocityIcon(budgetAnalytics.spendingVelocity)} 
+                  {Math.abs(budgetAnalytics.spendingVelocity).toFixed(1)}% MoM
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+          <Grid item xs={6}>
+            <Card variant="outlined" sx={{ textAlign: 'center' }}>
+              <CardContent sx={{ py: 1, '&:last-child': { pb: 1 } }}>
+                <Typography variant="caption" color="textSecondary">
+                  Target Monthly
+                </Typography>
+                <Typography 
+                  variant="body2" 
+                  fontWeight="bold"
+                  color={budgetAnalytics.targetMonthlySpending < budgetAnalytics.monthlyRunRate ? 'error' : 'success.main'}
+                >
+                  {formatCurrency(budgetAnalytics.targetMonthlySpending)}
+                </Typography>
+                <Typography variant="caption" color="textSecondary">
+                  {budgetAnalytics.monthsRemaining.toFixed(1)} months left
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        </Grid>
+      )}
+
       <ChartContainer
         width={width + 20}
         height={height}
@@ -158,7 +319,7 @@ function BudgetChart(props: Readonly<BudgetChartProps>) {
             min: 0,
             max:
               view === BUDGET_VIEW.ANNUAL
-                ? max([...accumulatedCosts, budgetAmount])
+                ? max([...accumulatedCosts, budgetAmount, budgetAnalytics.confidenceRange.high])
                 : max([...nonAccumulatedCosts, budgetAmount]),
             valueFormatter: value => {
               return formatCurrency(value || 0);
@@ -189,14 +350,56 @@ function BudgetChart(props: Readonly<BudgetChartProps>) {
           }}
           labelStyle={{ fill: theme.palette.error.main, fontSize: '0.9em' }}
         />
+        {/* Add projection line for annual view */}
+        {view === BUDGET_VIEW.ANNUAL && annualBudget?.amount && (
+          <>
+            <ChartsReferenceLine
+              y={budgetAnalytics.projectedAnnualSpending}
+              label={`Projected: ${formatCurrency(budgetAnalytics.projectedAnnualSpending)}`}
+              labelAlign="start"
+              lineStyle={{
+                stroke: theme.palette.warning.main,
+                strokeDasharray: '3 3',
+                strokeWidth: 1.5,
+                strokeOpacity: 0.8,
+              }}
+              labelStyle={{ fill: theme.palette.warning.main, fontSize: '0.8em' }}
+            />
+            {/* Confidence Range - High */}
+            <ChartsReferenceLine
+              y={budgetAnalytics.confidenceRange.high}
+              label={`High: ${formatCurrency(budgetAnalytics.confidenceRange.high)}`}
+              labelAlign="start"
+              lineStyle={{
+                stroke: theme.palette.grey[400],
+                strokeDasharray: '2 2',
+                strokeWidth: 1,
+                strokeOpacity: 0.5,
+              }}
+              labelStyle={{ fill: theme.palette.grey[600], fontSize: '0.7em' }}
+            />
+            {/* Confidence Range - Low */}
+            <ChartsReferenceLine
+              y={budgetAnalytics.confidenceRange.low}
+              label={`Low: ${formatCurrency(budgetAnalytics.confidenceRange.low)}`}
+              labelAlign="start"
+              lineStyle={{
+                stroke: theme.palette.grey[400],
+                strokeDasharray: '2 2',
+                strokeWidth: 1,
+                strokeOpacity: 0.5,
+              }}
+              labelStyle={{ fill: theme.palette.grey[600], fontSize: '0.7em' }}
+            />
+          </>
+        )}
         <ChartsXAxis />
         <ChartsYAxis />
         <ChartsTooltip />
       </ChartContainer>
-      <div style={{ textAlign: 'center', fontWeight: 'bold' }}>
-        <ProviderIcon provider={provider} /> {provider}
-      </div>
-      <div style={{ textAlign: 'center' }}>
+      
+      
+      <Box sx={{ textAlign: 'center' }}>
         <Button onClick={() => setOpenManageBudget(true)}>Manage budget</Button>
         <Dialog fullWidth maxWidth="sm" open={openManageBudget} onClose={() => setOpenManageBudget(false)}>
           <form onSubmit={updateBudget}>
@@ -226,8 +429,140 @@ function BudgetChart(props: Readonly<BudgetChartProps>) {
             </DialogActions>
           </form>
         </Dialog>
-      </div>
+      </Box>
     </Paper>
+  );
+}
+
+interface BudgetInsightsProps {
+  reports: Report[];
+}
+
+function BudgetInsights({ reports }: BudgetInsightsProps) {
+  const [budgets, setBudgets] = useState<Budget[]>([]);
+  const infraWalletApi = useApi(infraWalletApiRef);
+
+  useEffect(() => {
+    const fetchBudgets = async () => {
+      try {
+        const response = await infraWalletApi.getBudgets('default');
+        setBudgets(response.data || []);
+      } catch (error) {
+        // Failed to fetch budgets - silent error handling
+      }
+    };
+    fetchBudgets();
+  }, [infraWalletApi]);
+
+  const insights = reports.map(report => {
+    const budget = budgets.find(b => b.provider.toLowerCase() === report.id.toLowerCase());
+    if (!budget?.amount) return null;
+    
+    const analytics = calculateBudgetAnalytics(report.reports, budget.amount);
+    return { provider: report.id, budget, analytics };
+  }).filter(Boolean);
+
+  const totalBudget = budgets.reduce((sum, b) => sum + (b.amount || 0), 0);
+  const totalProjected = insights.reduce((sum, i) => sum + (i?.analytics.projectedAnnualSpending || 0), 0);
+  const overBudgetProviders = insights.filter(i => i?.analytics.budgetHealthStatus === 'critical');
+  const atRiskProviders = insights.filter(i => i?.analytics.budgetHealthStatus === 'warning');
+
+  const getRecommendations = () => {
+    const recommendations = [];
+    
+    if (overBudgetProviders.length > 0) {
+      recommendations.push({
+        type: 'critical',
+        message: `${overBudgetProviders.length} provider(s) are over budget: ${overBudgetProviders.map(p => p?.provider).join(', ')}`
+      });
+    }
+    
+    if (atRiskProviders.length > 0) {
+      recommendations.push({
+        type: 'warning', 
+        message: `${atRiskProviders.length} provider(s) at risk: ${atRiskProviders.map(p => p?.provider).join(', ')}`
+      });
+    }
+    
+    if (totalProjected > totalBudget) {
+      recommendations.push({
+        type: 'info',
+        message: `Total projected spending (${formatCurrency(totalProjected)}) exceeds total budget (${formatCurrency(totalBudget)}) by ${formatCurrency(totalProjected - totalBudget)}`
+      });
+    }
+
+    const highVelocityProviders = insights.filter(i => i?.analytics && i.analytics.spendingVelocity > 20);
+    if (highVelocityProviders.length > 0) {
+      recommendations.push({
+        type: 'warning',
+        message: `High spending acceleration detected in: ${highVelocityProviders.map(p => p?.provider).join(', ')}`
+      });
+    }
+
+    return recommendations;
+  };
+
+  const recommendations = getRecommendations();
+
+  if (insights.length === 0) return null;
+
+  return (
+    <Card sx={{ mb: 3 }}>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>Budget Insights</Typography>
+        
+        {/* Overview Stats */}
+        <Grid container spacing={2} sx={{ mb: 2 }}>
+          <Grid item xs={3}>
+            <Box textAlign="center">
+              <Typography variant="h4" color="primary">{insights.length}</Typography>
+              <Typography variant="caption">Providers</Typography>
+            </Box>
+          </Grid>
+          <Grid item xs={3}>
+            <Box textAlign="center">
+              <Typography variant="h4" color={overBudgetProviders.length > 0 ? 'error' : 'success.main'}>
+                {overBudgetProviders.length}
+              </Typography>
+              <Typography variant="caption">Over Budget</Typography>
+            </Box>
+          </Grid>
+          <Grid item xs={3}>
+            <Box textAlign="center">
+              <Typography variant="h4" color={atRiskProviders.length > 0 ? 'warning.main' : 'success.main'}>
+                {atRiskProviders.length}
+              </Typography>
+              <Typography variant="caption">At Risk</Typography>
+            </Box>
+          </Grid>
+          <Grid item xs={3}>
+            <Box textAlign="center">
+              <Typography variant="h4" color={totalProjected > totalBudget ? 'error' : 'success.main'}>
+                {((totalProjected / totalBudget) * 100).toFixed(0)}%
+              </Typography>
+              <Typography variant="caption">Projected vs Budget</Typography>
+            </Box>
+          </Grid>
+        </Grid>
+
+        {/* Recommendations */}
+        {recommendations.length > 0 && (
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>Recommendations</Typography>
+            {recommendations.map((rec, index) => (
+              <Chip
+                key={index}
+                label={rec.message}
+                size="small"
+                color={getRecommendationColor(rec.type)}
+                variant="outlined"
+                sx={{ mr: 1, mb: 1, maxWidth: '100%' }}
+              />
+            ))}
+          </Box>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 
@@ -260,21 +595,28 @@ export const Budgets: FC<BudgetsProps> = ({ providerErrorsSetter }) => {
 
   return (
     <Grid container spacing={3}>
-      <Grid item>
-        <Typography variant="h5">
-          {moment().year()} {budgetView} Budgets
-        </Typography>
+      <Grid item xs={12}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Typography variant="h5">
+            {moment().year()} {budgetView} Budgets
+          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography variant="body2">Annual</Typography>
+            <Switch
+              size="small"
+              onChange={event => setBudgetView(event.target.checked ? BUDGET_VIEW.MONTHLY : BUDGET_VIEW.ANNUAL)}
+            />
+            <Typography variant="body2">Monthly</Typography>
+          </Box>
+        </Box>
       </Grid>
-      <Grid container justifyContent="flex-end" spacing={1}>
-        <Grid item>Annual</Grid>
-        <Grid item>
-          <Switch
-            size="small"
-            onChange={event => setBudgetView(event.target.checked ? BUDGET_VIEW.MONTHLY : BUDGET_VIEW.ANNUAL)}
-          />
+      
+      {/* Budget Insights Panel */}
+      {reportsAggregatedAndMerged && (
+        <Grid item xs={12}>
+          <BudgetInsights reports={reportsAggregatedAndMerged} />
         </Grid>
-        <Grid item>Monthly</Grid>
-      </Grid>
+      )}
       {reportsAggregatedAndMerged !== undefined ? (
         reportsAggregatedAndMerged.map(report => (
           <Grid item key={`${report.id}-grid`} xs={4}>

--- a/plugins/infrawallet/src/components/Budgets/Budgets.tsx
+++ b/plugins/infrawallet/src/components/Budgets/Budgets.tsx
@@ -565,7 +565,7 @@ function BudgetInsights({ reports }: BudgetInsightsProps) {
             <Typography variant="subtitle2" gutterBottom>
               Recommendations
             </Typography>
-            {recommendations.map((rec) => (
+            {recommendations.map(rec => (
               <Chip
                 key={`${rec.type}-${rec.message}`}
                 label={rec.message}

--- a/plugins/infrawallet/src/components/Budgets/Budgets.tsx
+++ b/plugins/infrawallet/src/components/Budgets/Budgets.tsx
@@ -565,9 +565,9 @@ function BudgetInsights({ reports }: BudgetInsightsProps) {
             <Typography variant="subtitle2" gutterBottom>
               Recommendations
             </Typography>
-            {recommendations.map((rec, index) => (
+            {recommendations.map((rec) => (
               <Chip
-                key={index}
+                key={`${rec.type}-${rec.message}`}
                 label={rec.message}
                 size="small"
                 color={getRecommendationColor(rec.type)}


### PR DESCRIPTION
adding additional simple datapoints and breakdowns to the budgets page, this is a simplified version of something ive been batting around in my head on the best way to display open to any changes but thought this was a good starting point.

current version
![](https://opensource.electrolux.one/infrawallet/images/budgets.png)

new with budgets
<img width="1498" height="641" alt="image" src="https://github.com/user-attachments/assets/c865aea3-9878-484f-9f5d-5e335e847b10" />

<img width="1510" height="730" alt="image" src="https://github.com/user-attachments/assets/a1c360b2-2fbc-461a-863d-ab205367c2a6" />


without budgets
<img width="1505" height="542" alt="image" src="https://github.com/user-attachments/assets/ce7b3537-4637-44e8-bbb1-fee6ef16e103" />
