### PR TITLE
feat(zod schemas): adding zod schemas to all cost clients

### DIFF
--- a/plugins/infrawallet-backend/src/cost-clients/ConfluentClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/ConfluentClient.ts
@@ -10,6 +10,7 @@ import {
   NUMBER_OF_MONTHS_FETCHING_HISTORICAL_COSTS,
   GRANULARITY,
 } from '../service/consts';
+import { cryptoRandom } from '../service/crypto';
 import { ConfluentEnvironmentSchema, ConfluentBillingResponseSchema } from '../schemas/ConfluentBilling';
 import { ZodError } from 'zod';
 
@@ -118,7 +119,7 @@ export class ConfluentClient extends InfraWalletClient {
       if (response.status === 429 && retryCount < maxRetries) {
         // Apply exponential backoff with jitter for rate limiting
         const retryAfter = parseInt(response.headers.get('retry-after') || '30', 10);
-        const jitter = Math.random() * 2;
+        const jitter = cryptoRandom() * 2;
         const backoffTime = Math.min(120, retryAfter * Math.pow(1.5, retryCount) * jitter);
         this.logger.warn(`Rate limited, backing off for ${Math.ceil(backoffTime)} seconds...`);
         await new Promise(resolve => setTimeout(resolve, backoffTime * 1000));

--- a/plugins/infrawallet-backend/src/cost-clients/MockClient.ts
+++ b/plugins/infrawallet-backend/src/cost-clients/MockClient.ts
@@ -4,8 +4,11 @@ import { promises as fsPromises } from 'fs';
 import moment from 'moment';
 import * as upath from 'upath';
 import { CLOUD_PROVIDER, PROVIDER_TYPE } from '../service/consts';
+import { cryptoRandom } from '../service/crypto';
 import { CostQuery, Report } from '../service/types';
 import { InfraWalletClient } from './InfraWalletClient';
+
+// Helper function to generate cryptographically secure random numbers
 
 export class MockClient extends InfraWalletClient {
   static create(config: Config, database: DatabaseService, cache: CacheService, logger: LoggerService) {
@@ -85,7 +88,7 @@ export class MockClient extends InfraWalletClient {
   }
 
   getRandomValue(min: number, max: number): number {
-    const random = Math.random();
+    const random = cryptoRandom();
     const amplifiedRandom = Math.pow(random, 3);
     return amplifiedRandom * (max - min) + min;
   }

--- a/plugins/infrawallet-backend/src/metric-providers/MockProvider.ts
+++ b/plugins/infrawallet-backend/src/metric-providers/MockProvider.ts
@@ -3,6 +3,7 @@ import { Config } from '@backstage/config';
 import moment from 'moment';
 import { MetricProvider } from './MetricProvider';
 import { Metric, MetricQuery } from '../service/types';
+import { cryptoRandom } from '../service/crypto';
 
 export class MockProvider extends MetricProvider {
   static create(config: Config, database: DatabaseService, cache: CacheService, logger: LoggerService) {
@@ -44,7 +45,7 @@ export class MockProvider extends MetricProvider {
     let cursor = moment(parseInt(query.startTime, 10));
     while (cursor <= moment(parseInt(query.endTime, 10))) {
       const period = cursor.format(query.granularity === 'daily' ? 'YYYY-MM-DD' : 'YYYY-MM');
-      metric.reports[period] = Math.floor(Math.random() * (maxValue - minValue) + minValue);
+      metric.reports[period] = Math.floor(cryptoRandom() * (maxValue - minValue) + minValue);
       cursor = cursor.add(1, query.granularity === 'daily' ? 'days' : 'months');
     }
 

--- a/plugins/infrawallet-backend/src/schemas/AWSBilling.ts
+++ b/plugins/infrawallet-backend/src/schemas/AWSBilling.ts
@@ -1,0 +1,150 @@
+import { z } from 'zod';
+
+export const AWSGranularitySchema = z.enum(['DAILY', 'MONTHLY', 'HOURLY']);
+
+export const AWSDimensionValueSchema = z.object({
+  Value: z.string().optional(),
+  Attributes: z.record(z.string()).optional(),
+  MatchOptions: z.array(z.string()).optional(),
+});
+
+export const AWSDimensionValueAttributesSchema = z.object({
+  Value: z.string().optional(),
+  Attributes: z.record(z.string()).optional(),
+});
+
+export const AWSMetricValueSchema = z.object({
+  Amount: z.string().optional(),
+  Unit: z.string().optional(),
+});
+
+export const AWSGroupSchema = z.object({
+  Keys: z.array(z.string()).optional(),
+  Metrics: z.record(AWSMetricValueSchema).optional(),
+});
+
+export const AWSResultByTimeSchema = z.object({
+  TimePeriod: z
+    .object({
+      Start: z.string().optional(),
+      End: z.string().optional(),
+    })
+    .optional(),
+  Total: z.record(AWSMetricValueSchema).optional(),
+  Groups: z.array(AWSGroupSchema).optional(),
+  Estimated: z.boolean().optional(),
+});
+
+export const AWSGetCostAndUsageResponseSchema = z.object({
+  NextPageToken: z.string().optional(),
+  GroupDefinitions: z
+    .array(
+      z.object({
+        Type: z.string().optional(),
+        Key: z.string().optional(),
+      }),
+    )
+    .optional(),
+  ResultsByTime: z.array(AWSResultByTimeSchema).optional(),
+  DimensionValueAttributes: z.array(AWSDimensionValueAttributesSchema).optional(),
+});
+
+export const AWSGetTagsResponseSchema = z.object({
+  NextPageToken: z.string().optional(),
+  Tags: z.array(z.string()).optional(),
+  ReturnSize: z.number().optional(),
+  TotalSize: z.number().optional(),
+});
+
+export const AWSExpressionSchema: z.ZodType<any> = z.lazy(() =>
+  z.object({
+    Or: z.array(AWSExpressionSchema).optional(),
+    And: z.array(AWSExpressionSchema).optional(),
+    Not: AWSExpressionSchema.optional(),
+    Dimensions: z
+      .object({
+        Key: z.string().optional(),
+        Values: z.array(z.string()).optional(),
+        MatchOptions: z.array(z.string()).optional(),
+      })
+      .optional(),
+    Tags: z
+      .object({
+        Key: z.string().optional(),
+        Values: z.array(z.string()).optional(),
+        MatchOptions: z.array(z.string()).optional(),
+      })
+      .optional(),
+    CostCategories: z
+      .object({
+        Key: z.string().optional(),
+        Values: z.array(z.string()).optional(),
+        MatchOptions: z.array(z.string()).optional(),
+      })
+      .optional(),
+  }),
+);
+
+export const AWSGetCostAndUsageRequestSchema = z.object({
+  TimePeriod: z.object({
+    Start: z.string(),
+    End: z.string(),
+  }),
+  Granularity: AWSGranularitySchema,
+  Metrics: z.array(z.string()),
+  GroupBy: z
+    .array(
+      z.object({
+        Type: z.string(),
+        Key: z.string(),
+      }),
+    )
+    .optional(),
+  Filter: AWSExpressionSchema.optional(),
+  NextPageToken: z.string().optional(),
+});
+
+export const AWSGetTagsRequestSchema = z.object({
+  TimePeriod: z.object({
+    Start: z.string(),
+    End: z.string(),
+  }),
+  TagKey: z.string().optional(),
+  Filter: AWSExpressionSchema.optional(),
+  SortBy: z
+    .array(
+      z.object({
+        Key: z.string(),
+        SortOrder: z.enum(['ASCENDING', 'DESCENDING']).optional(),
+      }),
+    )
+    .optional(),
+  MaxResults: z.number().optional(),
+  NextPageToken: z.string().optional(),
+});
+
+export const AWSBillingErrorSchema = z.object({
+  name: z.string(),
+  message: z.string(),
+  $fault: z.string().optional(),
+  $metadata: z
+    .object({
+      httpStatusCode: z.number().optional(),
+      requestId: z.string().optional(),
+      cfId: z.string().optional(),
+    })
+    .optional(),
+});
+
+export type AWSGranularity = z.infer<typeof AWSGranularitySchema>;
+export type AWSDimensionValue = z.infer<typeof AWSDimensionValueSchema>;
+export type AWSDimensionValueAttributes = z.infer<typeof AWSDimensionValueAttributesSchema>;
+export type AWSMetricValue = z.infer<typeof AWSMetricValueSchema>;
+export type AWSGroup = z.infer<typeof AWSGroupSchema>;
+export type AWSResultByTime = z.infer<typeof AWSResultByTimeSchema>;
+export type AWSGetCostAndUsageResponse = z.infer<typeof AWSGetCostAndUsageResponseSchema>;
+export type AWSGetTagsResponse = z.infer<typeof AWSGetTagsResponseSchema>;
+export type AWSExpression = z.infer<typeof AWSExpressionSchema>;
+export type AWSGetCostAndUsageRequest = z.infer<typeof AWSGetCostAndUsageRequestSchema>;
+export type AWSGetTagsRequest = z.infer<typeof AWSGetTagsRequestSchema>;
+export type AWSBillingError = z.infer<typeof AWSBillingErrorSchema>;

--- a/plugins/infrawallet-backend/src/schemas/AzureBilling.ts
+++ b/plugins/infrawallet-backend/src/schemas/AzureBilling.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod';
+
+export const AzureGranularitySchema = z.enum(['Daily', 'Monthly', 'None']);
+export const AzureQueryTypeSchema = z.enum(['ActualCost', 'AmortizedCost', 'Usage']);
+
+export const AzureTimeframeSchema = z.enum([
+  'MonthToDate',
+  'BillingMonthToDate',
+  'TheLastMonth',
+  'TheLastBillingMonth',
+  'WeekToDate',
+  'Custom',
+]);
+
+export const AzureGroupingTypeSchema = z.enum(['Dimension', 'TagKey']);
+
+export const AzureGroupingSchema = z.object({
+  type: AzureGroupingTypeSchema,
+  name: z.string(),
+});
+
+export const AzureTimePeriodSchema = z.object({
+  from: z.string().or(z.date()),
+  to: z.string().or(z.date()),
+});
+
+export const AzureDatasetSchema = z.object({
+  granularity: AzureGranularitySchema,
+  aggregation: z
+    .record(
+      z.object({
+        name: z.string(),
+        function: z.string(),
+      }),
+    )
+    .optional(),
+  grouping: z.array(AzureGroupingSchema).optional(),
+  sorting: z
+    .array(
+      z.object({
+        direction: z.enum(['ascending', 'descending']),
+        name: z.string(),
+      }),
+    )
+    .optional(),
+  filter: z
+    .object({
+      and: z.array(z.any()).optional(),
+      or: z.array(z.any()).optional(),
+      not: z.any().optional(),
+      dimension: z
+        .object({
+          name: z.string(),
+          operator: z.string(),
+          values: z.array(z.string()),
+        })
+        .optional(),
+      tag: z
+        .object({
+          name: z.string(),
+          operator: z.string(),
+          values: z.array(z.string()),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+
+export const AzureQueryDefinitionSchema = z.object({
+  type: AzureQueryTypeSchema,
+  timeframe: AzureTimeframeSchema,
+  timePeriod: AzureTimePeriodSchema.optional(),
+  dataset: AzureDatasetSchema,
+  includeMonetaryCommitment: z.boolean().optional(),
+});
+
+export const AzureColumnInfoSchema = z.object({
+  name: z.string(),
+  type: z.string(),
+});
+
+export const AzureBillingResponsePropertiesSchema = z.object({
+  nextLink: z.string().optional(),
+  columns: z.array(AzureColumnInfoSchema),
+  rows: z.array(z.array(z.any())),
+});
+
+export const AzureBillingResponseSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().optional(),
+  type: z.string().optional(),
+  location: z.string().optional(),
+  sku: z.string().optional(),
+  eTag: z.string().optional(),
+  properties: AzureBillingResponsePropertiesSchema,
+});
+
+export const AzureBillingErrorSchema = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+    target: z.string().optional(),
+    details: z
+      .array(
+        z.object({
+          code: z.string(),
+          message: z.string(),
+          target: z.string().optional(),
+        }),
+      )
+      .optional(),
+    innererror: z
+      .object({
+        code: z.string().optional(),
+        message: z.string().optional(),
+      })
+      .optional(),
+  }),
+});
+
+export type AzureGranularity = z.infer<typeof AzureGranularitySchema>;
+export type AzureQueryType = z.infer<typeof AzureQueryTypeSchema>;
+export type AzureTimeframe = z.infer<typeof AzureTimeframeSchema>;
+export type AzureGroupingType = z.infer<typeof AzureGroupingTypeSchema>;
+export type AzureGrouping = z.infer<typeof AzureGroupingSchema>;
+export type AzureTimePeriod = z.infer<typeof AzureTimePeriodSchema>;
+export type AzureDataset = z.infer<typeof AzureDatasetSchema>;
+export type AzureQueryDefinition = z.infer<typeof AzureQueryDefinitionSchema>;
+export type AzureColumnInfo = z.infer<typeof AzureColumnInfoSchema>;
+export type AzureBillingResponseProperties = z.infer<typeof AzureBillingResponsePropertiesSchema>;
+export type AzureBillingResponse = z.infer<typeof AzureBillingResponseSchema>;
+export type AzureBillingError = z.infer<typeof AzureBillingErrorSchema>;

--- a/plugins/infrawallet-backend/src/schemas/ConfluentBilling.ts
+++ b/plugins/infrawallet-backend/src/schemas/ConfluentBilling.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+
+export const ConfluentEnvironmentSchema = z.object({
+  id: z.string(),
+  display_name: z.string(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+});
+
+export const ConfluentUsageRecordSchema = z.object({
+  id: z.string().optional(),
+  resource: z.object({
+    id: z.string(),
+    display_name: z.string().optional(),
+    environment: z.object({
+      id: z.string(),
+    }),
+  }),
+  metric: z.string(),
+  granularity: z.string(),
+  start_date: z.string(),
+  end_date: z.string(),
+  unit: z.string(),
+  value: z.number(),
+  price: z.number().optional(),
+});
+
+export const ConfluentBillingResponseSchema = z.object({
+  data: z.array(ConfluentUsageRecordSchema),
+  meta: z
+    .object({
+      first: z.string().optional(),
+      last: z.string().optional(),
+      prev: z.string().optional(),
+      next: z.string().optional(),
+      total_size: z.number().optional(),
+    })
+    .optional(),
+});
+
+export const ConfluentBillingRequestSchema = z.object({
+  'resource.environment': z.string().optional(),
+  'resource.id': z.string().optional(),
+  metric: z.string().optional(),
+  granularity: z.enum(['DAILY', 'HOURLY']).optional(),
+  start_date: z.string(),
+  end_date: z.string(),
+});
+
+export const ConfluentBillingErrorSchema = z.object({
+  error_code: z.string(),
+  message: z.string(),
+  details: z
+    .array(
+      z.object({
+        '@type': z.string(),
+        detail: z.string(),
+      }),
+    )
+    .optional(),
+});
+
+export type ConfluentEnvironment = z.infer<typeof ConfluentEnvironmentSchema>;
+export type ConfluentUsageRecord = z.infer<typeof ConfluentUsageRecordSchema>;
+export type ConfluentBillingResponse = z.infer<typeof ConfluentBillingResponseSchema>;
+export type ConfluentBillingRequest = z.infer<typeof ConfluentBillingRequestSchema>;
+export type ConfluentBillingError = z.infer<typeof ConfluentBillingErrorSchema>;

--- a/plugins/infrawallet-backend/src/schemas/CustomProviderBilling.ts
+++ b/plugins/infrawallet-backend/src/schemas/CustomProviderBilling.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+
+// Custom cost amortization mode enum
+export const CustomCostAmortizationModeSchema = z.enum(['lump_sum', 'average']);
+
+// Custom cost database record schema
+export const CustomCostRecordSchema = z.object({
+  id: z.string().optional(),
+  provider: z.string(),
+  account: z.string(),
+  service: z.string(),
+  category: z.string(),
+  cost: z.string().or(z.number()),
+  usage_month: z.number(),
+  amortization_mode: CustomCostAmortizationModeSchema.optional(),
+  tags: z.string().or(z.record(z.string())).optional(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+});
+
+// Custom cost API input schema (for creating/updating custom costs)
+export const CustomCostInputSchema = z.object({
+  provider: z.string().min(1),
+  account: z.string().min(1),
+  service: z.string().min(1),
+  category: z.string().min(1),
+  cost: z.number().min(0),
+  usage_month: z.number().int().min(202001).max(209912), // YYYYMM format
+  amortization_mode: CustomCostAmortizationModeSchema.default('lump_sum'),
+  tags: z.record(z.string()).optional().default({}),
+});
+
+// Custom cost query schema
+export const CustomCostQuerySchema = z.object({
+  provider: z.string().optional(),
+  account: z.string().optional(),
+  service: z.string().optional(),
+  category: z.string().optional(),
+  start_date: z.string().or(z.date()),
+  end_date: z.string().or(z.date()),
+  tags: z.record(z.string()).optional(),
+});
+
+// Custom cost bulk upload schema
+export const CustomCostBulkUploadSchema = z.object({
+  costs: z.array(CustomCostInputSchema).min(1).max(1000),
+});
+
+// Custom cost response schema
+export const CustomCostResponseSchema = z.object({
+  data: z.array(CustomCostRecordSchema),
+  total: z.number(),
+  page: z.number().optional(),
+  pageSize: z.number().optional(),
+});
+
+// Error response schema
+export const CustomProviderErrorSchema = z.object({
+  message: z.string(),
+  code: z.string().optional(),
+  details: z.record(z.any()).optional(),
+  timestamp: z.string().optional(),
+});
+
+// Types derived from schemas
+export type CustomCostAmortizationMode = z.infer<typeof CustomCostAmortizationModeSchema>;
+export type CustomCostRecord = z.infer<typeof CustomCostRecordSchema>;
+export type CustomCostInput = z.infer<typeof CustomCostInputSchema>;
+export type CustomCostQuery = z.infer<typeof CustomCostQuerySchema>;
+export type CustomCostBulkUpload = z.infer<typeof CustomCostBulkUploadSchema>;
+export type CustomCostResponse = z.infer<typeof CustomCostResponseSchema>;
+export type CustomProviderError = z.infer<typeof CustomProviderErrorSchema>;

--- a/plugins/infrawallet-backend/src/schemas/DatadogBilling.ts
+++ b/plugins/infrawallet-backend/src/schemas/DatadogBilling.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+
+export const DatadogChargeTypeSchema = z.enum(['usage', 'commitment', 'total']);
+export const DatadogViewSchema = z.enum(['sub-org', 'parent-org']);
+
+export const DatadogChargeSchema = z.object({
+  chargeType: DatadogChargeTypeSchema.optional(),
+  productName: z.string().optional(),
+  billableUnitName: z.string().optional(),
+  unitPrice: z.number().optional(),
+  billingUnit: z.string().optional(),
+  includedUnitCount: z.number().optional(),
+  totalUsage: z.number().optional(),
+  totalCost: z.number().optional(),
+  cost: z.number().optional(),
+});
+
+export const DatadogCostByOrgAttributesSchema = z.object({
+  orgName: z.string().optional(),
+  publicId: z.string().optional(),
+  date: z.string().optional(),
+  region: z.string().optional(),
+  charges: z.array(DatadogChargeSchema).optional(),
+});
+
+export const DatadogCostByOrgSchema = z.object({
+  type: z.string().optional(),
+  id: z.string().optional(),
+  attributes: DatadogCostByOrgAttributesSchema.optional(),
+});
+
+export const DatadogCostByOrgResponseSchema = z.object({
+  data: z.array(DatadogCostByOrgSchema).optional(),
+  meta: z
+    .object({
+      pagination: z
+        .object({
+          nextRecordId: z.string().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+
+export const DatadogHistoricalCostRequestSchema = z.object({
+  startMonth: z.string().or(z.date()),
+  endMonth: z.string().or(z.date()),
+  view: DatadogViewSchema.optional(),
+  includeConnectedAccounts: z.boolean().optional(),
+});
+
+export const DatadogEstimatedCostRequestSchema = z.object({
+  startMonth: z.string().or(z.date()),
+  endMonth: z.string().or(z.date()),
+  view: DatadogViewSchema.optional(),
+  includeConnectedAccounts: z.boolean().optional(),
+});
+
+export const DatadogBillingErrorSchema = z.object({
+  errors: z.array(
+    z.object({
+      detail: z.string(),
+      status: z.string().optional(),
+      title: z.string().optional(),
+      source: z
+        .object({
+          pointer: z.string().optional(),
+          parameter: z.string().optional(),
+        })
+        .optional(),
+    }),
+  ),
+});
+
+export type DatadogChargeType = z.infer<typeof DatadogChargeTypeSchema>;
+export type DatadogView = z.infer<typeof DatadogViewSchema>;
+export type DatadogCharge = z.infer<typeof DatadogChargeSchema>;
+export type DatadogCostByOrgAttributes = z.infer<typeof DatadogCostByOrgAttributesSchema>;
+export type DatadogCostByOrg = z.infer<typeof DatadogCostByOrgSchema>;
+export type DatadogCostByOrgResponse = z.infer<typeof DatadogCostByOrgResponseSchema>;
+export type DatadogHistoricalCostRequest = z.infer<typeof DatadogHistoricalCostRequestSchema>;
+export type DatadogEstimatedCostRequest = z.infer<typeof DatadogEstimatedCostRequestSchema>;
+export type DatadogBillingError = z.infer<typeof DatadogBillingErrorSchema>;

--- a/plugins/infrawallet-backend/src/schemas/GCPBilling.ts
+++ b/plugins/infrawallet-backend/src/schemas/GCPBilling.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+
+export const GCPBillingRowSchema = z.object({
+  service: z.object({
+    id: z.string(),
+    description: z.string(),
+  }),
+  sku: z.object({
+    id: z.string(),
+    description: z.string(),
+  }),
+  usage_start_time: z.string().optional(),
+  usage_end_time: z.string().optional(),
+  project: z.object({
+    id: z.string(),
+    name: z.string().optional(),
+    labels: z.record(z.string()).optional(),
+  }),
+  labels: z.record(z.string()).optional(),
+  system_labels: z.record(z.string()).optional(),
+  location: z
+    .object({
+      location: z.string().optional(),
+      country: z.string().optional(),
+      region: z.string().optional(),
+      zone: z.string().optional(),
+    })
+    .optional(),
+  export_time: z.string().optional(),
+  cost: z.number(),
+  currency: z.string(),
+  currency_conversion_rate: z.number().optional(),
+  usage: z
+    .object({
+      amount: z.number().optional(),
+      unit: z.string().optional(),
+      amount_in_pricing_units: z.number().optional(),
+      pricing_unit: z.string().optional(),
+    })
+    .optional(),
+  credits: z
+    .array(
+      z.object({
+        name: z.string(),
+        amount: z.number(),
+        full_name: z.string().optional(),
+        id: z.string().optional(),
+        type: z.string().optional(),
+      }),
+    )
+    .optional(),
+  invoice: z.object({
+    month: z.string(),
+  }),
+  cost_type: z.string().optional(),
+  adjustment_info: z
+    .object({
+      id: z.string().optional(),
+      description: z.string().optional(),
+      mode: z.string().optional(),
+      type: z.string().optional(),
+    })
+    .optional(),
+});
+
+export const GCPBillingQueryResultSchema = z.array(GCPBillingRowSchema);
+
+export type GCPBillingRow = z.infer<typeof GCPBillingRowSchema>;
+export type GCPBillingQueryResult = z.infer<typeof GCPBillingQueryResultSchema>;

--- a/plugins/infrawallet-backend/src/schemas/GitHubBilling.ts
+++ b/plugins/infrawallet-backend/src/schemas/GitHubBilling.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const GitHubUsageItemSchema = z.object({
+  date: z.string(),
+  product: z.string(),
+  sku: z.string(),
+  quantity: z.number(),
+  unitType: z.string(),
+  pricePerUnit: z.number(),
+  grossAmount: z.number(),
+  discountAmount: z.number(),
+  netAmount: z.number(),
+  organizationName: z.string(),
+  repositoryName: z.string().optional(),
+});
+
+export const GitHubBillingResponseSchema = z.object({
+  usageItems: z.array(GitHubUsageItemSchema),
+});
+
+export const GitHubBillingErrorSchema = z.object({
+  message: z.string(),
+  documentation_url: z.string().optional(),
+});
+
+export type GitHubUsageItem = z.infer<typeof GitHubUsageItemSchema>;
+export type GitHubBillingResponse = z.infer<typeof GitHubBillingResponseSchema>;
+export type GitHubBillingError = z.infer<typeof GitHubBillingErrorSchema>;

--- a/plugins/infrawallet-backend/src/schemas/MongoAtlasBilling.ts
+++ b/plugins/infrawallet-backend/src/schemas/MongoAtlasBilling.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+
+export const MongoAtlasInvoiceSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  salesTaxCents: z.number().optional(),
+  subtotalCents: z.number().optional(),
+  totalCents: z.number().optional(),
+  statusName: z.string().optional(),
+  created: z.string().optional(),
+  updated: z.string().optional(),
+  amountBilledCents: z.number().optional(),
+  amountPaidCents: z.number().optional(),
+  creditsCents: z.number().optional(),
+  endDate: z.string().optional(),
+  startDate: z.string().optional(),
+  linkedInvoices: z.array(z.string()).optional(),
+  payments: z
+    .array(
+      z.object({
+        amountCents: z.number(),
+        created: z.string(),
+        id: z.string(),
+        statusName: z.string(),
+        updated: z.string(),
+      }),
+    )
+    .optional(),
+});
+
+export const MongoAtlasInvoicesResponseSchema = z.object({
+  links: z
+    .array(
+      z.object({
+        href: z.string(),
+        rel: z.string(),
+      }),
+    )
+    .optional(),
+  results: z.array(MongoAtlasInvoiceSchema),
+  totalCount: z.number().optional(),
+});
+
+export const MongoAtlasCSVLineItemSchema = z.object({
+  'Organization ID': z.string(),
+  'Organization Name': z.string(),
+  'Project ID': z.string(),
+  'Project Name': z.string(),
+  'Cluster Name': z.string().optional(),
+  'Cluster Type': z.string().optional(),
+  SKU: z.string(),
+  Description: z.string(),
+  'Start Date': z.string(),
+  'End Date': z.string(),
+  Quantity: z.string().transform(Number),
+  'Unit of Measure': z.string(),
+  'Unit Price': z.string().transform(Number),
+  'Total Price': z.string().transform(Number),
+  'Additional Info': z.string().optional(),
+});
+
+export const MongoAtlasInvoicesRequestSchema = z.object({
+  orgId: z.string(),
+  fromDate: z.string(),
+  toDate: z.string(),
+});
+
+export const MongoAtlasCSVRequestSchema = z.object({
+  orgId: z.string(),
+  invoiceId: z.string(),
+});
+
+export const MongoAtlasBillingErrorSchema = z.object({
+  detail: z.string().optional(),
+  error: z.number().optional(),
+  errorCode: z.string().optional(),
+  parameters: z.record(z.string()).optional(),
+  reason: z.string().optional(),
+});
+
+export type MongoAtlasInvoice = z.infer<typeof MongoAtlasInvoiceSchema>;
+export type MongoAtlasInvoicesResponse = z.infer<typeof MongoAtlasInvoicesResponseSchema>;
+export type MongoAtlasCSVLineItem = z.infer<typeof MongoAtlasCSVLineItemSchema>;
+export type MongoAtlasInvoicesRequest = z.infer<typeof MongoAtlasInvoicesRequestSchema>;
+export type MongoAtlasCSVRequest = z.infer<typeof MongoAtlasCSVRequestSchema>;
+export type MongoAtlasBillingError = z.infer<typeof MongoAtlasBillingErrorSchema>;

--- a/plugins/infrawallet-backend/src/service/crypto.ts
+++ b/plugins/infrawallet-backend/src/service/crypto.ts
@@ -1,0 +1,12 @@
+import { randomBytes } from 'crypto';
+
+/**
+ * Generates a cryptographically secure random number between 0 and 1.
+ * This is a drop-in replacement for Math.random() that uses the crypto module
+ * for better security in applications that require unpredictable random values.
+ *
+ * @returns A random number between 0 (inclusive) and 1 (exclusive)
+ */
+export function cryptoRandom(): number {
+  return randomBytes(4).readUInt32BE(0) / 0x100000000;
+}

--- a/plugins/infrawallet/src/components/EntityInfraWalletCard/EntityInfraWalletCard.tsx
+++ b/plugins/infrawallet/src/components/EntityInfraWalletCard/EntityInfraWalletCard.tsx
@@ -309,8 +309,8 @@ const TotalCostTab = ({
         <LineChart data={chartData}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="period" />
-          <YAxis />
-          <Tooltip />
+          <YAxis tickFormatter={(value: number) => `$${value.toFixed(0)}`} />
+          <Tooltip formatter={(value: number) => `$${value.toFixed(NUM_DIGITS_AFTER_DECIMALPOINT)}`} />
           <Legend />
           {projects.map((project, index) => (
             <Line

--- a/plugins/infrawallet/src/components/EntityInfraWalletCard/EntityInfraWalletCard.tsx
+++ b/plugins/infrawallet/src/components/EntityInfraWalletCard/EntityInfraWalletCard.tsx
@@ -212,7 +212,7 @@ export function getChartData(
       const total = projectReports.reduce((sum, report) => {
         return sum + (report.reports[period] ?? 0);
       }, 0);
-      dataPoint[project] = total.toFixed(NUM_DIGITS_AFTER_DECIMALPOINT);
+      dataPoint[project] = total;
     });
     return dataPoint;
   });


### PR DESCRIPTION
finishing some work started a few months back in regards to adding schema validation to the api fetches with zod, previously only the elastic cloud client had the validations.

tested:
* confluent
* mongoatlas
* gcp
* aws
* elastic

not able to test due to lacking accounts
* azure
* datadog
* github