### PR TITLE
fix tags with special chars

### DIFF
--- a/plugins/infrawallet/src/hooks/useInfraWalletLuceneParams.test.ts
+++ b/plugins/infrawallet/src/hooks/useInfraWalletLuceneParams.test.ts
@@ -256,6 +256,17 @@ describe('useInfraWalletLuceneParams', () => {
       expect(decodeURIComponent(newParams.get('q') || '')).toBe('tag:aws.env=prod');
     });
 
+    it('should update tags with key that contains special character in URL as Lucene query', () => {
+      const { result } = renderHookAndGetResult();
+
+      const updatedSearchParams = getUpdatedSearchParams(result, {
+        selectedTags: [{ provider: 'azure', key: 'org:env', value: 'prod' }],
+      });
+      const decoded = decodeURIComponent(updatedSearchParams.get('q') || '');
+
+      expect(decoded).toBe('tag:"azure.org:env=prod"');
+    });
+
     it('should update both filters and tags in Lucene query', () => {
       const { result } = renderHookAndGetResult();
 

--- a/plugins/infrawallet/src/hooks/useInfraWalletLuceneParams.ts
+++ b/plugins/infrawallet/src/hooks/useInfraWalletLuceneParams.ts
@@ -93,6 +93,20 @@ const quoteLuceneValue = (value: string): string => {
 };
 
 /**
+ * Quote a tag for Lucene query if a key contains special characters
+ */
+const quoteTag = (provider: string, key: string, value: string): string => {
+  const specialChars = /[/()[\]{}\s:]/;
+  const tag = `${provider}.${key}=${value}`;
+
+  // If tag has special character in the key, it needs to be quoted. E.g. tag:"AWS.key:environment=staging"
+  if (specialChars.test(key)) {
+    return `tag:"${tag}"`;
+  }
+  return `tag:${tag}`;
+};
+
+/**
  * Convert Filters and Tags to Lucene query string
  */
 const filtersAndTagsToLucene = (filters: Filters, tags: Tag[]): string => {
@@ -115,7 +129,7 @@ const filtersAndTagsToLucene = (filters: Filters, tags: Tag[]): string => {
   for (const tag of tags) {
     if (tag.provider && tag.key && tag.value) {
       // Use the new format: tag:provider.key=value
-      queryParts.push(`tag:${tag.provider}.${tag.key}=${tag.value}`);
+      queryParts.push(quoteTag(tag.provider, tag.key, tag.value));
     }
   }
 


### PR DESCRIPTION
**Issue:**
If a tag has a key that contains special characters, Lucene fails to parse it. For example, the tag `AWS.key:environment=staging` is incorrect since the key "key:environment" has column. URL with incorrect tags doesn't set proper filter and tag values when copied.

**Solution**
The fix is to quote a tag value which allows Lucene to parse it correctly:
`tag:"AWS.key:environment=staging"` 
