### PR TITLE
 fix datadog data loading

### DIFF
--- a/plugins/infrawallet-backend/src/schemas/DatadogBilling.ts
+++ b/plugins/infrawallet-backend/src/schemas/DatadogBilling.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const DatadogChargeTypeSchema = z.enum(['usage', 'commitment', 'total']);
+export const DatadogChargeTypeSchema = z.enum(['usage', 'commitment', 'total', 'on_demand', 'committed']);
 export const DatadogViewSchema = z.enum(['sub-org', 'parent-org']);
 export const DatadogCostByOrgTypeSchema = z.enum(['cost_by_org']);
 


### PR DESCRIPTION
<img width="1449" height="455" alt="image" src="https://github.com/user-attachments/assets/5d8f569b-734c-4114-a718-22262201c9de" />
getHistoricalCostByOrg only supports ranges of maximum 2 months. 
Opening the Budgets tab automatically tries to fetch data from the start of the year so we are hit with this issue. Same problem occurs when you have a longer range than 2 months in the Overview.

This PR fixes the DataDogClient by splitting the requested interval into 2 month chunks. It is slightly slower but I didn't encounter any API throttling even with longer ranges of 1-2 years.

Further, I noticed warnings that the expected types in DatadogChargeTypeSchema is missing 2 charge types and decided to include them. 
<img width="675" height="448" alt="image" src="https://github.com/user-attachments/assets/10e2c8b0-d7df-4e7f-ad10-7cbde0ba2620" />
